### PR TITLE
feat:enable sitemap preset

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -73,6 +73,12 @@ const config: Config = {
         theme: {
           customCss: './src/css/custom.css',
         },
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
Sitemap file verified on https://feat-sitemap.docs-68d.pages.dev/sitemap.xml

// Sitemap plugin will not work under dev environment. only 'build'.