### PR TITLE
feat:enable gtag

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -79,6 +79,10 @@ const config: Config = {
           ignorePatterns: ['/tags/**'],
           filename: 'sitemap.xml',
         },
+        gtag: {
+          trackingID: 'G-6D7SV64NSJ',
+          anonymizeIP: true,
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
verified on https://feat-enable-google-analytics.docs-68d.pages.dev/
New property for whole official site: ZenUML.com Official Site

// gtag plugin won't work on dev env, only generated by pnpm build