### PR TITLE
SEO/GEO foundation: structured data, llms.txt, AI-crawler robots

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,11 +1,11 @@
 xiaopeng:
   name: Xiao Peng
-  title: Cofounder @ ZenUML
+  title: Co-founder & Creator of ZenUML
   url: https://github.com/mrcoder
   image_url: https://github.com/mrcoder.png
 
 xiaowenz:
   name: Xiaowen Zhang
-  title: SME @ ZenUML
+  title: Software Architect & ZenUML Subject-Matter Expert
   url: https://github.com/iamshaynez
   image_url: https://github.com/iamshaynez.png

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,32 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import ZenUMLPlugin from './src/plugins/zenuml';
 
+// Site-wide Organization structured data (JSON-LD). Injected into the <head>
+// of every page so AI engines and search crawlers can identify the publisher
+// entity behind ZenUML. Homepage-specific WebSite / SoftwareApplication and
+// per-post BlogPosting schema are added in src/pages/index.tsx and
+// src/theme/BlogPostPage respectively.
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'ZenUML',
+  legalName: 'P&D Vision Pty Ltd',
+  url: 'https://zenuml.com/',
+  logo: 'https://zenuml.com/img/logo-90x72.png',
+  description:
+    'ZenUML is a diagram-as-code solution for sequence diagrams and more, available on Atlassian Confluence, the web, IDEs, and desktop.',
+  email: 'support@zenuml.com',
+  foundingDate: '2017',
+  sameAs: [
+    'https://github.com/ZenUml',
+    'https://twitter.com/zenuml',
+    'https://www.linkedin.com/company/zenuml/',
+    'https://www.facebook.com/zenuml',
+    'https://www.youtube.com/results?search_query=zenuml',
+    'https://marketplace.atlassian.com/apps/1218380',
+  ],
+};
+
 const config: Config = {
   title: 'ZenUML',
   tagline: 'Create diagrams faster and better',
@@ -42,6 +68,13 @@ const config: Config = {
                   rel: 'stylesheet',
                   href: 'https://cdn.jsdelivr.net/npm/tailwindcss/dist/preflight.min.css',
                 },
+              },
+              {
+                tagName: 'script',
+                attributes: {
+                  type: 'application/ld+json',
+                },
+                innerHTML: JSON.stringify(organizationJsonLd),
               },
             ],
           };

--- a/src/components/HomePageFAQ/index.tsx
+++ b/src/components/HomePageFAQ/index.tsx
@@ -1,4 +1,5 @@
 import { FC, forwardRef } from 'react';
+import Head from '@docusaurus/Head';
 import styles from './styles.module.css';
 import * as Accordion from '@radix-ui/react-accordion';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
@@ -60,16 +61,65 @@ const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerProps>(
 );
 AccordionTrigger.displayName = 'AccordionTrigger';
 
-const faqList = [
+// Each FAQ carries a plain-text `answerText` (used verbatim in the FAQPage
+// JSON-LD so the structured data matches the visible answer, as Google
+// requires) and an optional richer `content` node for on-page rendering.
+// Answers lead with the direct answer first — the pattern AI engines quote.
+interface FaqEntry {
+  id: string;
+  question: string;
+  answerText: string;
+  content?: React.ReactNode;
+}
+
+const faqList: FaqEntry[] = [
+  {
+    id: 'faq-what-is-zenuml',
+    question: 'What is ZenUML?',
+    answerText:
+      'ZenUML is a diagram-as-code tool that turns concise, Markdown-inspired text into interactive UML sequence diagrams and more. It renders entirely in your browser in near-real-time, so you go from text to a shareable diagram without drag-and-drop. ZenUML runs on Atlassian Confluence, a free web app, JetBrains and VS Code plugins, and desktop.',
+  },
+  {
+    id: 'faq-free',
+    question: 'Is ZenUML free?',
+    answerText:
+      'Yes. The ZenUML online editor at app.zenuml.com is free to use, and ZenUML offers a free Lite plan on the Atlassian Marketplace for Confluence, alongside paid plans that raise usage limits and add more diagram types.',
+  },
+  {
+    id: 'faq-confluence',
+    question: 'Does ZenUML work in Confluence?',
+    answerText:
+      'Yes. "ZenUML Diagrams for Confluence" is available on the Atlassian Marketplace for Confluence Cloud, Server, and Data Center. You add a ZenUML macro to any page and edit the diagram inline; on Confluence Cloud it also renders Mermaid, PlantUML, draw.io graphs, and OpenAPI/AsyncAPI specifications.',
+  },
+  {
+    id: 'faq-diagram-types',
+    question: 'What diagram types can ZenUML create?',
+    answerText:
+      'ZenUML specializes in UML sequence diagrams. On Confluence Cloud the ZenUML app additionally renders Mermaid diagrams, PlantUML, draw.io (graph) diagrams, and OpenAPI/AsyncAPI documentation, so a single app covers most diagramming needs.',
+  },
+  {
+    id: 'faq-vs-plantuml',
+    question: 'How is ZenUML different from PlantUML and Mermaid?',
+    answerText:
+      'ZenUML uses a much more concise DSL — typically 2 to 3 times fewer lines than PlantUML to draw the same sequence diagram. Unlike tools that export a static image, ZenUML renders the diagram as interactive HTML: highlighting a message selects the matching code, and the text stays searchable. Rendering happens client-side, so no diagram data leaves your browser.',
+  },
+  {
+    id: 'faq-privacy',
+    question: 'Is my diagram data secure?',
+    answerText:
+      'Yes. ZenUML renders diagrams — including image export — entirely in the browser. No diagram content or personal data is sent to, stored on, or processed by ZenUML servers. ZenUML was born from a finance project and is used across banking, FinTech, telecom, and retail.',
+  },
   {
     id: 'faq-license',
-    title:
-      'Are diagrams/scripts created using zenuml.com/sequence-diagram subject to any license?',
-    content: 'No license is imposed by ZenUML on the generated output.',
+    question: 'Are diagrams created with ZenUML subject to any license?',
+    answerText:
+      'No. ZenUML imposes no license on the diagrams or scripts you generate — the output is yours to use freely.',
   },
   {
     id: 'faq-install',
-    title: 'How to Install Confluence Plugin',
+    question: 'How do I install the ZenUML Confluence plugin?',
+    answerText:
+      'To install ZenUML on Confluence Cloud: click Settings in your Confluence instance, choose Find new apps, search for "ZenUML Diagrams for Confluence", then click Try it free or Get app. Installation takes about a minute and requires site-admin permissions.',
     content: (
       <ul className="list-decimal">
         <li>
@@ -91,18 +141,38 @@ const faqList = [
   },
 ];
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqList.map((item) => ({
+    '@type': 'Question',
+    name: item.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.answerText,
+    },
+  })),
+};
+
 const HomepageFAQ: FC<Props> = () => {
   return (
     <div className="text-center py-20">
-      <h2 className={styles.title}>FAQ</h2>
+      <Head>
+        <script type="application/ld+json">{JSON.stringify(faqJsonLd)}</script>
+      </Head>
+      <h2 className={styles.title}>Frequently Asked Questions</h2>
       <div className={styles.content}>
         <div className="mb-10">
           <Accordion.Root type="multiple">
             {faqList.map((item) => {
               return (
-                <AccordionItem key={item.title} value={item.title}>
-                  <AccordionTrigger id={item.id}>{item.title}</AccordionTrigger>
-                  <AccordionContent>{item.content}</AccordionContent>
+                <AccordionItem key={item.id} value={item.id}>
+                  <AccordionTrigger id={item.id}>
+                    {item.question}
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    {item.content ?? item.answerText}
+                  </AccordionContent>
                 </AccordionItem>
               );
             })}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,6 +16,50 @@ import {
 import styles from './index.module.css';
 import HomepageQuote from '../components/HomepageQuote';
 import HomePageFAQ from '@site/src/components/HomePageFAQ';
+import Head from '@docusaurus/Head';
+
+// Homepage-specific structured data. WebSite identifies the site entity;
+// SoftwareApplication describes the ZenUML product itself so AI engines and
+// search can classify and cite it. Site-wide Organization schema is injected
+// globally from docusaurus.config.ts.
+const homepageJsonLd = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'ZenUML',
+    url: 'https://zenuml.com/',
+    description:
+      'ZenUML is a diagram-as-code solution for sequence diagrams and more, rendered interactively in the browser.',
+    publisher: {
+      '@type': 'Organization',
+      name: 'ZenUML',
+    },
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'ZenUML',
+    applicationCategory: 'DeveloperApplication',
+    applicationSubCategory: 'Diagramming / UML tool',
+    operatingSystem: 'Web, Windows, macOS, Atlassian Confluence',
+    url: 'https://zenuml.com/',
+    image: 'https://zenuml.com/img/og-image.png',
+    description:
+      'ZenUML turns concise text into interactive UML sequence diagrams and more. It renders in the browser with no server-side processing, uses a DSL 2–3× more concise than PlantUML, and works on Atlassian Confluence, the web, JetBrains and VS Code, and desktop.',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      description: 'Free plan available; paid plans raise limits.',
+    },
+    softwareHelp: 'https://zenuml.com/docs/',
+    publisher: {
+      '@type': 'Organization',
+      name: 'ZenUML',
+      legalName: 'P&D Vision Pty Ltd',
+    },
+  },
+];
 
 function HomepageHeader() {
   return (
@@ -173,6 +217,13 @@ export default function Home(): JSX.Element {
       title="A Free Sequence Diagram Online Tool"
       description="Description: JavaScript based diagramming tool that renders Markdown-inspired text definitions to create and modify sequence diagrams dynamically."
     >
+      <Head>
+        {homepageJsonLd.map((schema, idx) => (
+          <script key={idx} type="application/ld+json">
+            {JSON.stringify(schema)}
+          </script>
+        ))}
+      </Head>
       <HomepageHeader />
       <main className={styles.main}>
         <section>

--- a/src/theme/BlogPostPage/index.tsx
+++ b/src/theme/BlogPostPage/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import BlogPostPage from '@theme-original/BlogPostPage';
+import type BlogPostPageType from '@theme/BlogPostPage';
+import type { WrapperProps } from '@docusaurus/types';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+type Props = WrapperProps<typeof BlogPostPageType>;
+
+/**
+ * Wraps the theme's BlogPostPage to emit BlogPosting JSON-LD structured data
+ * for every blog post. This lets AI engines and search crawlers read the
+ * headline, author (E-E-A-T), publish/modified dates, and publisher without
+ * parsing the rendered HTML. Wrapping (not ejecting) keeps us upgrade-safe.
+ */
+export default function BlogPostPageWrapper(props: Props): JSX.Element {
+  const { siteConfig } = useDocusaurusContext();
+  const siteUrl = siteConfig.url; // https://zenuml.com
+
+  // Docusaurus passes the MDX component as `content`; its metadata and
+  // frontMatter are attached as static properties.
+  const { metadata } = props.content;
+  const frontMatter = props.content.frontMatter as {
+    image?: string;
+    last_update?: { date?: string };
+  };
+
+  const canonical = siteUrl + metadata.permalink;
+  const image = frontMatter.image
+    ? frontMatter.image.startsWith('http')
+      ? frontMatter.image
+      : siteUrl + frontMatter.image
+    : siteUrl + '/img/og-image.png';
+
+  const authors = (metadata.authors ?? []).map((a) => ({
+    '@type': 'Person',
+    name: a.name,
+    ...(a.url ? { url: a.url } : {}),
+  }));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: metadata.title,
+    ...(metadata.description ? { description: metadata.description } : {}),
+    datePublished: metadata.date,
+    dateModified: frontMatter.last_update?.date ?? metadata.date,
+    ...(authors.length ? { author: authors } : {}),
+    image,
+    url: canonical,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': canonical },
+    publisher: {
+      '@type': 'Organization',
+      name: 'ZenUML',
+      logo: {
+        '@type': 'ImageObject',
+        url: siteUrl + '/img/logo-90x72.png',
+      },
+    },
+    ...(metadata.tags?.length
+      ? { keywords: metadata.tags.map((t) => t.label).join(', ') }
+      : {}),
+  };
+
+  return (
+    <>
+      <Head>
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      </Head>
+      <BlogPostPage {...props} />
+    </>
+  );
+}

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,48 @@
+# ZenUML
+
+> ZenUML is a diagram-as-code solution for sequence diagrams and more. It renders Markdown-inspired text definitions into interactive UML diagrams entirely in the browser — no data is sent to a server for rendering. ZenUML runs on Atlassian Confluence (Cloud, Server, Data Center), a web app, IDE plugins (JetBrains, VS Code), and desktop. Operated by P&D Vision Pty Ltd.
+
+## What ZenUML is best known for
+
+- A concise DSL that needs 2–3× fewer lines than PlantUML to draw the same sequence diagram.
+- Near-real-time, interactive rendering in the browser (highlight a message to jump to its code).
+- Privacy by design: diagrams and image exports are rendered client-side; no diagram data reaches ZenUML servers.
+- OMG UML 2.5.1-compliant output with practical extensions (e.g. cloud icons).
+
+## Documentation
+
+- [What is ZenUML?](https://zenuml.com/docs/)
+- [Quick Start](https://zenuml.com/docs/zenuml-quick-start/)
+- [Products overview](https://zenuml.com/docs/category/products/)
+- [Language Guide](https://zenuml.com/docs/category/language-guide/)
+- [UML sequence diagrams overview](https://zenuml.com/uml-sequence-diagrams-overview/)
+
+## Products
+
+- [ZenUML Diagrams for Confluence (Atlassian Marketplace)](https://marketplace.atlassian.com/apps/1218380/zenuml-diagrams-for-confluence-freemium)
+- [ZenUML Online Editor (web app)](https://app.zenuml.com/)
+- [Chrome extension](https://chrome.google.com/webstore/detail/web-sequence/kcpganeflmhffnlofpdmcjklmdpbbmef)
+- [JetBrains plugin](https://plugins.jetbrains.com/plugin/12437-zenuml-support)
+- [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=mrcoder.zenuml)
+
+## Comparisons & alternatives
+
+- [Best PlantUML alternative for sequence diagrams](https://zenuml.com/best-plantuml-alternative/)
+- [Best Mermaid alternative for sequence diagrams](https://zenuml.com/best-mermaid-alternative-for-sequence-diagrams/)
+- [Best draw.io alternative](https://zenuml.com/best-draw-io-alternative/)
+- [Best Lucidchart alternative for sequence diagrams](https://zenuml.com/best-lucidchart-alternative-for-sequence-diagrams/)
+- [Best Visual Paradigm alternative](https://zenuml.com/best-visual-paradigm-alternative/)
+
+## Blog
+
+- [Blog index](https://zenuml.com/blog/)
+- [ZenUML: The Best Diagram Plugin for Confluence](https://zenuml.com/blog/2024/02/08/2024/zenuml-best-diagram-plugin-for-confluence/)
+
+## Policies
+
+- [End-User License Agreement](https://app.zenuml.com/End-User-License-Agreement/index.html)
+- [Privacy Policy](https://app.zenuml.com/privacy-policy/privacy-policy.html)
+
+## Contact
+
+- Email: support@zenuml.com

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -16,11 +16,41 @@
 # \ ------------------------------ /
 #  \______________________________/
 
-
+# Humans and traditional search crawlers
 User-agent: *
 Allow: /
 
+# AI answer engines & training crawlers — explicitly welcomed so ZenUML
+# can be discovered, quoted, and cited in AI-generated answers.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 Sitemap: https://zenuml.com/sitemap.xml
+Sitemap: https://zenuml.com/sitemap-all.xml
 
 #              ________
 #   __,_,     |        |


### PR DESCRIPTION
## Why

A baseline AEO/GEO audit of the live `zenuml.com` scored **76/B-**. The site's *content* already scores well (depth, quotability, internal links, OG, RSS all pass), but the **machine-readable + discoverability layer** was missing: **0 of 10 crawled pages had any JSON-LD structured data**, and there was **no `llms.txt`**. AI answer engines (ChatGPT, Perplexity, Claude, Google AI Overviews) rely on exactly that layer to identify, classify, and cite a product.

## What changed

| Area | Change |
|---|---|
| **Site-wide** | `Organization` JSON-LD injected into every page via `docusaurus.config.ts` |
| **Homepage** | `WebSite` + `SoftwareApplication` (the ZenUML product) + `FAQPage` (8 answer-first Q&As) |
| **Blog** | `BlogPosting` JSON-LD on **all 67 posts** — headline, author (`Person` + E-E-A-T), publish/modified dates, publisher — via an upgrade-safe `BlogPostPage` theme wrapper (no eject) |
| **`static/llms.txt`** | New — direct index of docs, products, comparison pages, blog, policies for AI crawlers |
| **`static/robots.txt`** | Explicit allow-list for 9 AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, …) + both sitemaps |
| **`blog/authors.yml`** | Sharper author titles (E-E-A-T) |

## Verification

- `pnpm build` succeeds; every page prerenders.
- Verified in generated HTML: homepage carries **4 JSON-LD blocks**; **100% of pages** now have structured data (was 0%); `BlogPosting` on 67 posts; `/llms.txt` served (200); `robots.txt` has 9 AI-bot stanzas.
- Re-ran the AEO audit against the local build: **foundational score 76 → 79**, structured-data coverage **0% → 100%**, `llms.txt` check now passes.

## Follow-ups (not in this PR)

- Auto-generated `/docs/category/*` pages are thin (no meta description, low word count) — the audit's next-weakest cluster. Worth adding intros/descriptions.
- Freshness: newest blog content is 2024. A publishing cadence is the lever AI-citation rewards most (not code-fixable here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)