### PR TITLE
Mini Sites landing pages (/mini-sites, /embed-html-in-confluence, /best-html-macro-alternative-for-confluence)

### DIFF
--- a/docs/products/mini-sites-for-confluence.md
+++ b/docs/products/mini-sites-for-confluence.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 7
+title: Mini Sites For Confluence
+description: Run a folder of HTML, CSS and JavaScript live inside a Confluence page
+keywords:
+  - Mini Sites for Confluence
+  - embed HTML in Confluence
+  - run JavaScript in Confluence page
+  - clickable prototype Confluence
+  - Confluence dashboard macro
+  - Atlassian Forge app
+---
+
+# Mini Sites For Confluence
+
+Mini Sites embeds a **folder** of HTML, CSS, JavaScript and assets live on a Confluence page. A clickable
+prototype, a filterable dashboard, a calculator or a small internal tool runs inline — the real thing, not a
+screenshot of it.
+
+Marketplace listing:
+[Mini Sites (Embed HTML & Prototypes) for Confluence](https://marketplace.atlassian.com/apps/4169123443/mini-sites-embed-html-prototypes-for-confluence)
+· [35-second demo](https://youtu.be/vQfuQDDDXs8)
+
+## How to use
+
+### Installation
+
+1. Click **Settings** on your Confluence Cloud instance
+2. Click **Find new apps**
+3. Search for **Mini Sites**
+4. Click **Try it free** to install
+
+### Publish a mini site
+
+1. Edit any Confluence page and type `/Mini-Site` to insert the macro.
+2. Click **Upload**, then **Browse files…**, and select the folder that directly contains your `index.html`.
+3. The app validates the bundle, scans it for accidentally included credentials, and provisions it into an
+   isolated sandbox.
+4. Click **Validate & publish**, then publish the Confluence page.
+
+Nested folders and relative paths are preserved: `style.css`, `app.js`, `images/logo.png` and
+`assets/data.json` all resolve exactly as they do locally.
+
+## What it is good for
+
+- **Clickable prototypes** — put the UI you are asking people to approve on the same page as the PRD.
+- **Filterable dashboards** — a chart plus filters over a JSON file shipped in the bundle.
+- **Small internal tools** — pricing calculators, checklist generators, troubleshooting decision trees.
+- **Design-system demos** — components rendered from the CSS the product actually ships.
+
+## Permissions and isolation
+
+- Built on **Atlassian Forge**: Confluence page permissions are inherited. Anyone who can view the page can
+  use the mini site; nobody else can.
+- The app requests **no Confluence API scopes** — it does not read your page content.
+- Each macro instance is served from its own **isolated, non-routable sandbox**; there is no public URL.
+- Every bundle is **validated and secret-scanned** before it is served.
+
+## Limits
+
+| Limit | Value |
+|---|---:|
+| Files per bundle | 2,000 |
+| Maximum file size | 25 MiB |
+| Maximum bundle size | 50 MiB |
+| Required file | `index.html` at the folder root |
+
+The sandbox is static-only and has **no outbound network access** — external fonts, CDNs and API calls are
+unavailable, so bundle the assets you need. Absolute paths and `../` traversal are rejected at validation
+time.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `index.html` is not found | Select the folder that *directly* contains `index.html`, not its parent or a nested subfolder. |
+| CSS or JavaScript does not load | Use relative paths (`style.css`, `app.js`), not absolute ones. |
+| The upload is rejected as too large | Stay within the limits above. |
+| The upload panel is still showing | No bundle has been published for that macro instance yet. |
+| Viewing works but publishing is blocked | The Atlassian licence is inactive. Existing mini sites keep rendering. |
+
+## Learn more
+
+- [Mini Sites product page](/mini-sites)
+- [How to embed HTML in a Confluence page](/embed-html-in-confluence)
+- [Best HTML Macro alternative for Confluence](/best-html-macro-alternative-for-confluence)

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -199,6 +199,10 @@ const config: Config = {
               href: 'https://marketplace.atlassian.com/apps/1218380/zenuml-diagrams-for-confluence-freemium?hosting=cloud&tab=overview&src=landing',
             },
             {
+              label: 'Mini Sites for Confluence',
+              href: '/mini-sites',
+            },
+            {
               label: 'Online Editor',
               href: 'https://app.zenuml.com/',
             },

--- a/src/pages/best-html-macro-alternative-for-confluence.md
+++ b/src/pages/best-html-macro-alternative-for-confluence.md
@@ -1,0 +1,96 @@
+---
+title: Best HTML Macro alternative for Confluence Cloud
+description: 'Looking for an HTML macro alternative for Confluence Cloud? If what you actually want to embed is a multi-file app — HTML, CSS, JavaScript and assets — a snippet macro is the wrong shape. Here is the comparison, honestly.'
+keywords:
+  [
+    html macro alternative,
+    confluence html macro alternative,
+    best html macro for confluence,
+    confluence cloud html app,
+    embed html confluence cloud,
+    html macro pro alternative,
+  ]
+unlisted: false
+---
+
+# Best HTML Macro alternative for Confluence Cloud
+
+Most people searching for an HTML macro alternative are not looking for a *better snippet field*. They are
+looking for a way to put something **real and interactive** on a Confluence page — a prototype, a dashboard,
+a small tool — and the snippet macro is the only tool they have found so far.
+
+If that is you, the honest answer is that you want a different shape of app.
+
+## The two shapes
+
+**A snippet macro** takes markup you paste into a field and renders it. One file's worth of content. Anything
+else — your stylesheet, your JavaScript, your images, your data — has to be inlined into that one blob or
+loaded from an external CDN.
+
+**A bundle app** takes the *folder* you already have. [Mini Sites for Confluence](/mini-sites) validates it,
+scans it for accidentally included credentials, provisions it into an isolated sandbox, and renders it inline
+on the page with relative paths intact.
+
+## Comparison
+
+| | Snippet-style HTML macro | Mini Sites for Confluence |
+|---|---|---|
+| Input | Markup pasted into a field | A folder, up to 2,000 files |
+| Multi-file (CSS/JS/images/data) | Inline it, or use a CDN | Native — nested relative paths preserved |
+| Per-file / per-bundle size | Practical limit of a text field | 25 MiB / 50 MiB |
+| JavaScript | Runs | Runs |
+| External CDN / API calls | Usually allowed | **Not allowed** — bundle your assets |
+| Credential scanning before publish | No | Yes — AWS/GCP keys, tokens |
+| Isolation | Depends on the app | One non-routable sandbox per macro instance |
+| Access control | Page permissions | Page permissions (Forge, inherited) |
+| Atlassian API scopes requested | Varies | None |
+| Hosting to arrange | None | None |
+
+## When the snippet macro is the right answer
+
+Be honest with yourself before you switch:
+
+- You are pasting a **third-party embed code** — a form, a video, a status badge. Use the snippet macro.
+- You need to load a library **from a CDN at runtime**. Mini Sites' sandbox has no outbound network access;
+  the snippet macro will suit you better.
+- You want to inject CSS that restyles **the Confluence page itself**. That is outside a sandbox by
+  definition.
+
+## When the bundle app is the right answer
+
+- The thing you want to embed is **a project on your disk**, not a paragraph of markup.
+- Reviewers should be able to **click it**, not read a screenshot of it.
+- You do not want to stand up hosting, and you do not want a second access list to keep in sync with the
+  page.
+- You care that whatever you upload is **checked for leaked credentials** before it goes anywhere.
+
+## What it looks like
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/vQfuQDDDXs8" title="Embed a live HTML prototype in a Confluence page" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Thirty-five seconds, all of it a real capture: a prototype gets published from the page editor, validated and
+secret-scanned, and a teammate votes in it and settles the decision in the page comments.
+
+## Questions people ask
+
+**Can I migrate from an HTML macro to Mini Sites?**
+If your macro content is self-contained markup, save it as `index.html`, put any CSS/JS next to it, and
+publish the folder. If it depended on a CDN, download those assets into the folder first.
+
+**Does it work on Confluence Data Center?**
+No — Confluence **Cloud** only.
+
+**What happens to already-published mini sites if the licence lapses?**
+They keep rendering. What stops is publishing new bundles.
+
+**Is there a free option?**
+Pricing lives on the
+[Marketplace listing](https://marketplace.atlassian.com/apps/4169123443/mini-sites-embed-html-prototypes-for-confluence)
+— it is always current there.
+
+## Related
+
+- [Mini Sites for Confluence](/mini-sites)
+- [How to embed HTML in a Confluence page](/embed-html-in-confluence)
+
+[Install Mini Sites for Confluence →](https://marketplace.atlassian.com/apps/4169123443/mini-sites-embed-html-prototypes-for-confluence)

--- a/src/pages/embed-html-in-confluence.md
+++ b/src/pages/embed-html-in-confluence.md
@@ -1,0 +1,107 @@
+---
+title: How to embed HTML in a Confluence page
+description: 'Four ways to embed HTML in a Confluence Cloud page — iframe macro, HTML macro apps, attachments, and publishing a whole folder of HTML/CSS/JS with Mini Sites. What each one can and cannot do.'
+keywords:
+  [
+    embed html in confluence,
+    confluence html macro,
+    run javascript in confluence,
+    confluence iframe macro,
+    embed web page in confluence,
+    confluence cloud custom html,
+  ]
+unlisted: false
+---
+
+# How to embed HTML in a Confluence page
+
+Confluence Cloud removed the built-in HTML macro that Server and Data Center users remember, so "embed some
+HTML" now means picking one of four options. Here is what each one actually does, and where each one breaks.
+
+| Approach | Multi-file? | JavaScript runs? | Needs external hosting? | Access control |
+|---|---|---|---|---|
+| Iframe / embed macro | No — points at a URL | Yes, on the remote site | **Yes** | Whatever the remote site does |
+| HTML macro app | Snippet only | Yes | No, for a snippet | Page permissions |
+| Attach a `.html` file | No — one file, downloads | No | No | Page permissions |
+| **Publish a folder ([Mini Sites](/mini-sites))** | **Yes — up to 2,000 files** | **Yes** | **No** | **Page permissions** |
+
+## 1. The iframe / embed macro
+
+Confluence's built-in embed macro takes a URL and shows that page in an iframe.
+
+**Use it when** the thing you want to show already lives at a stable URL that your readers can reach — a
+Grafana board, a public demo, a Figma prototype.
+
+**It breaks when** the content does not have a URL yet. You have to host it somewhere first, keep that host
+alive, and give every reader access to it. For an internal prototype, that is three problems you did not
+have before.
+
+## 2. An HTML macro app from the Marketplace
+
+Several apps restore a snippet-level HTML macro to Confluence Cloud. You paste markup, it renders.
+
+**Use it when** you need a small piece of markup — a styled callout, a script tag, a third-party embed code.
+
+**It breaks when** the thing you want to embed is a *project*: an `index.html` plus a stylesheet plus a
+JavaScript bundle plus an `assets/` folder. A snippet field has nowhere to put the other files, so you end up
+inlining everything into one enormous blob, or pointing at a CDN and accepting the external dependency.
+
+## 3. Attaching the HTML file to the page
+
+You can attach `index.html` to a page. Readers download it and open it locally.
+
+**It breaks immediately**: the download is not rendered inline, relative assets are missing, and by the time
+someone opens it the file is a copy that no longer matches the page.
+
+## 4. Publish the whole folder onto the page
+
+This is what [Mini Sites for Confluence](/mini-sites) does. You select the folder that contains your
+`index.html`; the app validates it, scans it for accidentally included credentials, provisions it into an
+isolated sandbox, and renders it inline on the page.
+
+- **Multi-file**: up to 2,000 files, 25 MiB per file, 50 MiB per bundle. Nested paths are preserved, so
+  `assets/data.json` and `images/logo.png` resolve exactly as they do locally.
+- **JavaScript runs**: the bundle behaves in the page as it does on your laptop.
+- **No hosting to arrange**: there is no URL to create, no server to keep alive, no access list to maintain.
+- **Confluence permissions are inherited** — the app is built on Atlassian Forge, so anyone who can view the
+  page can use the mini site, and nobody else can.
+- **No outbound network access from the sandbox** — external fonts, CDNs and API calls do not work. Bundle
+  what you need. This is the trade that makes the whole thing safe to run inside a wiki.
+
+### Step by step
+
+1. Edit a Confluence page and type `/Mini-Site`.
+2. Click **Upload**, then **Browse files…**, and select the folder that directly contains `index.html`.
+3. Wait for the file list to appear, then click **Validate & publish**.
+4. Publish the Confluence page.
+
+## Which one should you use?
+
+- Embedding something that already has a URL and is already reachable → **iframe macro**.
+- Pasting a snippet or a third-party embed code → **HTML macro app**.
+- Putting a real, multi-file, interactive thing on the page → **publish the folder**
+  ([Mini Sites](/mini-sites)).
+
+## Questions people ask
+
+**Can I run JavaScript in a Confluence Cloud page?**
+Yes — through an app. Confluence will not execute raw `<script>` tags you type into the editor; an app that
+renders your code in a sandboxed frame will. Mini Sites does exactly that.
+
+**Why did my CSS not load?**
+Almost always an absolute path. Use `href="style.css"`, not `/style.css` or a full URL. Absolute paths and
+`../` traversal are rejected at validation time.
+
+**Can the embedded page call our internal API?**
+Not from the Mini Sites sandbox — it has no outbound network access. If you need live data, ship it as a JSON
+file in the bundle and re-publish when it changes.
+
+**Is the content private?**
+It follows the page. The sandbox is non-routable and has no public URL of its own.
+
+## Related
+
+- [Mini Sites for Confluence](/mini-sites)
+- [Best HTML Macro alternative for Confluence](/best-html-macro-alternative-for-confluence)
+
+[Install Mini Sites for Confluence →](https://marketplace.atlassian.com/apps/4169123443/mini-sites-embed-html-prototypes-for-confluence)

--- a/src/pages/mini-sites.md
+++ b/src/pages/mini-sites.md
@@ -1,0 +1,108 @@
+---
+title: Mini Sites for Confluence — embed a live HTML prototype
+description: 'Mini Sites for Confluence embeds a folder of HTML, CSS and JavaScript live on a Confluence page. A clickable prototype, a filterable dashboard or a small internal tool runs inline — the real thing, not a screenshot.'
+keywords:
+  [
+    mini sites for confluence,
+    confluence html app,
+    embed prototype in confluence,
+    interactive confluence page,
+    confluence dashboard macro,
+    clickable prototype confluence,
+  ]
+unlisted: false
+---
+
+# Mini Sites for Confluence
+
+**Mini Sites** is a Confluence Cloud app that takes a folder of HTML, CSS and JavaScript and runs it **live
+and interactive inside a Confluence page**. A clickable prototype, a filterable dashboard, a calculator or a
+small internal tool — the real thing running on the page, not a screenshot of it.
+
+[Install Mini Sites from the Atlassian Marketplace](https://marketplace.atlassian.com/apps/4169123443/mini-sites-embed-html-prototypes-for-confluence)
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/vQfuQDDDXs8" title="Embed a live HTML prototype in a Confluence page" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## The problem it solves
+
+A prototype that only runs on your laptop cannot be reviewed by the people who decide on it. The usual
+workarounds all lose something:
+
+- **Screenshots** — the interaction is gone; reviewers argue about what a click would have done.
+- **A link to a dev server or a hosting service** — one more system to keep alive, one more access list to
+  manage, and it breaks the moment the laptop sleeps.
+- **A pasted HTML snippet** — fine for a badge or an embed code, not for a multi-file app with its own CSS,
+  JavaScript and assets.
+
+Mini Sites removes the hosting step entirely: the folder you already have goes onto the page where the
+decision is being made.
+
+## How it works
+
+1. Edit any Confluence page and insert the **Mini-Site** macro (type `/Mini-Site`).
+2. Choose the folder that contains your `index.html`.
+3. The bundle is validated, scanned for accidentally committed credentials, and provisioned into its own
+   isolated sandbox.
+4. Publish the page. The mini site renders inline, and anyone who can view the page can use it.
+
+Nested folders and relative paths are preserved exactly as you built them — `style.css`, `app.js`,
+`images/logo.png`, `assets/data.json` all resolve.
+
+## What you can put on a page
+
+- **Clickable prototypes** — the UI you are asking the team to approve, running, on the page with the PRD.
+- **Filterable dashboards** — a chart and a set of filters over a JSON file you ship in the bundle.
+- **Small internal tools** — a pricing calculator, a checklist generator, a troubleshooting decision tree.
+- **Design system demos** — components rendered from the same CSS the app ships.
+
+## Permissions and security
+
+- **Confluence permissions are inherited.** The app is built on Atlassian Forge; access follows the page.
+  There is no second sharing model to keep in sync.
+- **The app requests no Confluence API scopes.** It does not read your page content.
+- **Each macro instance runs in its own isolated, non-routable sandbox** — there is no public URL to leak.
+- **Every bundle is validated and secret-scanned** before it is served: an `index.html` at the root, relative
+  paths only, no `../` traversal, and a scan for AWS/GCP keys and tokens.
+
+## Limits
+
+| Limit | Value |
+|---|---:|
+| Files per bundle | 2,000 |
+| Maximum file size | 25 MiB |
+| Maximum bundle size | 50 MiB |
+| Required file | `index.html` at the folder root |
+
+The sandbox is static-only and has **no outbound network access** — external fonts, CDNs and API calls are
+not available, so bundle the assets you need. That constraint is deliberate: it is what makes the mini site
+safe to run inside your wiki.
+
+## Questions people ask
+
+**Does JavaScript actually run?**
+Yes. The bundle runs in the browser exactly as it would locally — event handlers, state, canvas, the lot.
+What it cannot do is call out to the internet from the sandbox.
+
+**Is this an HTML macro?**
+No. An HTML macro takes a snippet or an iframe URL. Mini Sites takes a *folder* — many files, relative paths
+intact — and hosts it for you. See
+[Best HTML Macro alternative for Confluence](/best-html-macro-alternative-for-confluence).
+
+**Where are the files stored?**
+On Cloudflare infrastructure operated by us, one isolated sandbox per macro instance. No Confluence page
+content or personal data is sent there — only the bundle and the identifiers needed to serve it.
+
+**What happens if my licence lapses?**
+Already-published mini sites keep rendering; publishing new bundles is what stops.
+
+**Does it work on Confluence Data Center?**
+No. Mini Sites is Confluence **Cloud** only.
+
+## Related
+
+- [How to embed HTML in a Confluence page](/embed-html-in-confluence)
+- [Best HTML Macro alternative for Confluence](/best-html-macro-alternative-for-confluence)
+- [ZenUML Diagrams for Confluence](/docs/products/zenuml-diagrams-for-confluence) — sequence diagrams from
+  text, from the same team.
+
+[Install Mini Sites for Confluence →](https://marketplace.atlassian.com/apps/4169123443/mini-sites-embed-html-prototypes-for-confluence)


### PR DESCRIPTION
Three pages for **Mini Sites for Confluence**, built on the only SEO pattern this site has measured evidence for.

## Why these three, and why this shape

GSC (sc-domain:zenuml.com, 90 days to 2026-07-22) says the non-brand clicks on this domain come almost entirely from *"X alternative"* pages whose title is close to a verbatim restatement of the query:

| query | clicks | impressions | CTR | position |
|---|---:|---:|---:|---:|
| plantuml alternatives | 36 | 615 | 5.9% | 2.2 |
| plantuml alternative | 21 | 595 | 3.5% | 3.0 |
| mermaid alternatives | 17 | 1,288 | 1.3% | 5.0 |
| visual paradigm alternative | 9 | 227 | 4.0% | 4.5 |
| sequence diagram online | 25 | 3,666 | 0.7% | 9.7 ← impressions with no landing page |

The same data says the *technical* GEO pass shipped on 2026-07-08 (JSON-LD everywhere + `llms.txt`) produced **no measurable lift**: the 13 days after vs the 13 days before were 21.1 → 19.8 clicks/day, 1,985 → 1,380 impressions/day, position 10.6 → 14.2, on a decline that predates it (34.5 → 27.1 → 21.2 clicks/day across the three 30-day blocks). So: no new schema, no new `llms.txt`, no crawler allowlists here — just pages that answer a query.

## What's in it

| Page | Target query | Title length |
|---|---|---:|
| `/mini-sites` | mini sites for confluence | 64 |
| `/embed-html-in-confluence` | embed html in confluence / run javascript in confluence | 47 |
| `/best-html-macro-alternative-for-confluence` | html macro alternative | 57 |
| `docs/products/mini-sites-for-confluence` | product doc, matches the existing template | 34 |

Plus one footer entry under **Products**.

Every technical claim is taken from `conf-mini-sites/docs/listing/documentation.md` (2,000 files / 25 MiB / 50 MiB, root `index.html`, relative paths only, no outbound network from the sandbox, Forge page permissions, no API scopes, secret scan). The pages say plainly where a snippet HTML macro is the *better* choice — CDN-loaded libraries and restyling the Confluence page itself are things this app deliberately cannot do.

## Verification

- `npm run build` — clean; all four routes generated and present in `sitemap.xml`.
- Titles land at 34–64 chars after Docusaurus appends `| ZenUML` (the pre-existing pages double the suffix; these don't).
- All links to the listing use the **canonical** slug `…/apps/4169123443/mini-sites-embed-html-prototypes-for-confluence` — the slug in Atlassian's own sitemap is stale after the app rename.

## How we'll know it worked

At 2 and 4 weeks: search each page's title verbatim; success is top-5, the same bar the three existing comparison pages clear. Reminders are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx9cGpKVEa1b3XTUxPZToR