### PR TITLE
SEO: move the Confluence app landing section onto zenuml.com/confluence

### DIFF
--- a/docs/products/zenuml-diagrams-for-confluence.md
+++ b/docs/products/zenuml-diagrams-for-confluence.md
@@ -3,19 +3,23 @@ sidebar_position: 1
 title: ZenUML Diagrams For Confluence
 #sidebar_label: Quick Start
 #pagination_label: Quick Start
-description: Introduction of ZenUML Diagrams For Confluence
+description: How to install the ZenUML add-on in Confluence Cloud and insert your first diagram macro.
+# Product and comparison keywords live on /confluence/ — that page is the ranking
+# target for them. This page keeps how-to intent only, so the two do not compete
+# for the same queries.
 keywords:
-  - Confluence diagramming tool
-  - Atlassian Marketplace ZenUML
-  - Confluence diagram plugin
-  - UML diagram Confluence integration
-  - Mermaid diagrams plugin for Confluence
-  - Confluence UML diagram macro
-  - Software development diagramming Confluence
+  - how to use zenuml in confluence
+  - insert diagram macro confluence
+  - zenuml confluence editor guide
+  - confluence diagram macro tutorial
+  - universal plugin manager zenuml
 #slug: /quick-start
 ---
 
 # ZenUML Diagrams For Confluence
+
+For features, pricing, diagram types and FAQ, see [ZenUML for Confluence](/confluence). This page covers
+installation and day-to-day use.
 
 ![](../../static/img/docs/product-zenuml-for-confluence-01.webp)
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -196,7 +196,7 @@ const config: Config = {
           items: [
             {
               label: 'Diagrams for Confluence',
-              href: 'https://marketplace.atlassian.com/apps/1218380/zenuml-diagrams-for-confluence-freemium?hosting=cloud&tab=overview&src=landing',
+              href: '/confluence',
             },
             {
               label: 'Mini Sites for Confluence',

--- a/src/pages/confluence/diagram-types/drawio.md
+++ b/src/pages/confluence/diagram-types/drawio.md
@@ -1,0 +1,193 @@
+---
+title: DrawIO diagrams in Confluence Cloud
+description: 'Drag-and-drop flowcharts, network diagrams and org charts in Confluence using the DrawIO engine. No DrawIO account and no separate subscription.'
+keywords:
+  [
+    drawio confluence,
+    draw.io confluence alternative,
+    confluence flowchart macro,
+    network diagram confluence,
+    org chart confluence,
+    confluence graph diagram,
+  ]
+unlisted: false
+---
+
+Part of ZenUML for Confluence  ·  6 diagram types, one app
+
+# Full DrawIO Editor, Right in Confluence
+
+Create flowcharts, network diagrams, org charts, and any visual diagram using the open-source DrawIO engine — embedded directly into Confluence Cloud. No DrawIO account, no external tool, no copy-pasting images.
+
+[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [All Diagram Types](/confluence/diagram-types/)
+
+✓ Powered by the diagrams.net open-source engine ✓ No DrawIO account required ✓ Import existing .drawio files ✓ Renders in-browser — private by design
+
+## What is DrawIO in ZenUML for Confluence?
+
+ZenUML for Confluence includes a **full DrawIO diagram editor** as one of its six built-in diagram types. DrawIO (also known as diagrams.net) is the world's most widely used open-source diagramming engine — the same one that powers diagrams.net and the DrawIO desktop app. ZenUML embeds that engine directly inside Confluence Cloud, so you can create and edit visual diagrams without leaving your documentation.
+
+When you insert a ZenUML Graph macro on a Confluence page and choose the DrawIO type, the editor opens in a **fullscreen modal** inside Confluence. The full DrawIO canvas is available: shape libraries (general, network, flowchart, UML, BPMN, and more), smart connectors, layers, styling controls, and multi-page diagrams. When you click Save & Exit, the diagram is stored as **DrawIO XML** in Confluence custom content and displayed inline on the page.
+
+Because the DrawIO engine runs client-side in the browser, your diagram content is **never transmitted to ZenUML servers**. Diagrams are stored entirely within your Atlassian Confluence instance. No DrawIO account, no diagrams.net login, and no external subscription is required — only ZenUML for Confluence installed from the Atlassian Marketplace.
+
+## 8 Types of Diagrams You Can Build
+
+DrawIO's built-in shape libraries cover every common visual diagram type your team needs.
+
+### Flowcharts
+
+Map decisions, processes, and workflows with standard flowchart shapes — start/end terminals, decision diamonds, process boxes, and connectors with condition labels.
+
+### Network Diagrams
+
+Document cloud and on-premise infrastructure: servers, load balancers, databases, firewalls, and network zones. Includes AWS, Azure, and GCP icon libraries.
+
+### Org Charts
+
+Visualise team structures and reporting hierarchies. Add photos, titles, and department labels. Rearrange by dragging nodes — the connectors follow automatically.
+
+### Mind Maps
+
+Capture brainstorming sessions and topic hierarchies in a radial layout. Add branches, sub-branches, and colour coding directly on the canvas.
+
+### BPMN Process Flows
+
+Model business processes using BPMN 2.0 notation — events, gateways, tasks, pools, and lanes. Suitable for process analysis, audit trails, and compliance documentation.
+
+### UML Class Diagrams
+
+Draw class relationships, inheritance hierarchies, and interface implementations visually. Useful when a code-based tool like PlantUML is less convenient than direct canvas editing.
+
+### ER Diagrams
+
+Design database schemas visually with entities, attributes, and relationship cardinality lines. Export to PNG for handoff or keep updated inline on your Confluence data model page.
+
+### Architecture Diagrams
+
+Sketch system architecture — microservices, event buses, storage layers, and external integrations — with free-form shapes and custom icons. No fixed notation required.
+
+## When to use DrawIO vs. ZenUML DSL or Mermaid
+
+ZenUML for Confluence offers both visual and code-based diagram types. The right choice depends on your diagram style and who will maintain it.
+
+### Use DrawIO when…
+
+- Your team includes non-technical members who prefer a visual canvas
+- The diagram is spatial or network-topology-based, where layout matters as much as structure
+- You are working with existing `.drawio` or `.xml` files you want to reuse
+- You need custom icons, logos, or free-form shapes that cannot be expressed in text syntax
+- The diagram is an org chart, BPMN process flow, or infrastructure map
+- Precise pixel-level control over layout is important
+
+### Use ZenUML DSL or Mermaid when…
+
+- Your team lives in code editors and prefers text over drag-and-drop
+- The diagram represents a *sequence* of interactions — API calls, service flows, authentication flows
+- You want the diagram source checked into a Git repository alongside your code
+- You need to generate or regenerate diagrams from templates or scripts
+- You want diffs between diagram versions to be readable as text
+- The diagram will change frequently and textual editing is faster than canvas editing
+
+Both diagram types coexist in the same ZenUML for Confluence installation. You can use DrawIO for your architecture overview and ZenUML DSL for the API sequence diagrams — on the same page, in the same Confluence space.
+
+## Four steps from page to diagram
+
+The DrawIO editor is embedded inside Confluence — nothing to install beyond the ZenUML Forge app.
+
+1
+
+### Insert the macro
+
+On any Confluence page, type `/ZenUML` or open the macro picker. Select **Graph** as the diagram type.
+
+2
+
+### DrawIO editor opens
+
+The full DrawIO canvas opens in a **fullscreen modal** — shape panel on the left, canvas in the centre, properties on the right. The complete diagrams.net experience, inside Confluence.
+
+3
+
+### Create or edit your diagram
+
+Drag shapes from the library, draw connectors, add labels, apply styles, and arrange your layout. You can also paste in existing DrawIO XML to import a diagram you already have.
+
+4
+
+### Click Save & Exit
+
+The diagram is saved as DrawIO XML in Confluence custom content and displayed inline on the page. Every save creates a new version — recoverable at any time through Confluence version history.
+
+## Who uses DrawIO in Confluence and why
+
+DrawIO in ZenUML for Confluence serves teams across disciplines — from infrastructure engineers to product managers to HR operations.
+
+### Infrastructure teams documenting cloud architecture
+
+A DevOps or platform engineer uses DrawIO to maintain a network topology diagram on the Confluence space for their service. They drag in AWS and GCP shape icons, connect services with labelled arrows, and add firewall boundaries as swim lanes. Because the diagram lives on the Confluence page rather than in a separate draw.io file or Lucidchart document, it stays next to the runbooks and is updated by the same engineers who update the infrastructure.
+
+### Business analysts mapping BPMN process flows
+
+A business analyst uses the BPMN shape library to model an order-fulfilment process across three departments — Sales, Warehouse, and Finance — using pools and lanes. The diagram is attached to the process documentation Confluence page and reviewed in quarterly audits. When a step changes, the analyst opens the DrawIO editor directly from the page, makes the update, and publishes — no version mismatch between the document and the diagram.
+
+### HR and operations building org charts
+
+An HR operations manager keeps the company org chart on a Confluence page using DrawIO. Employee names, titles, and reporting lines are maintained in the canvas. When someone joins, leaves, or moves teams, the manager opens the macro, edits the node, and publishes. The org chart is always live — no stale PowerPoint exports pinned to the page.
+
+### Data engineers maintaining ER diagrams
+
+A data engineer uses DrawIO to draw an entity-relationship diagram for the core data model and embeds it on the data platform Confluence space. When the schema evolves, they open the editor, move the affected entities and relationships, and save. The Confluence page becomes the authoritative source-of-truth for the data model — reviewable by anyone on the team without a database tool.
+
+### Product managers facilitating workshop mind maps
+
+A product manager runs a discovery workshop and captures the output as a mind map in DrawIO directly on the meeting-notes Confluence page. Participants can see the diagram grow in real time as the PM updates it. After the session, the mind map stays embedded in the Confluence page — no need to export a screenshot and attach a file that immediately becomes out of date.
+
+## DrawIO in Confluence — Frequently Asked Questions
+
+Common questions about using DrawIO diagrams in Confluence via ZenUML.
+
+### Does DrawIO work the same as diagrams.net in ZenUML?
+
+Yes — ZenUML embeds the **same open-source DrawIO engine** that powers diagrams.net. You get the full canvas: shape libraries (general, network, flowchart, UML, BPMN, AWS, Azure, GCP), smart connectors, layers, styling, and multi-page diagrams. The editor runs entirely in your browser inside Confluence, so the experience is functionally identical to diagrams.net without needing to leave Confluence or maintain a separate account.
+
+### Can I import an existing .drawio file into Confluence?
+
+Yes. DrawIO diagrams are stored as **DrawIO XML**, which is the same format used by `.drawio` and `.xml` files created in diagrams.net or the DrawIO desktop app. To import an existing diagram, open the DrawIO editor in ZenUML and use **Extras > Edit Diagram** to paste the XML directly, or use **File > Import from** inside the editor. Your existing diagram will render exactly as it did in the standalone DrawIO tool.
+
+### Do I need a DrawIO account?
+
+**No.** ZenUML embeds the open-source DrawIO engine and runs it entirely inside Confluence. You do not need a diagrams.net account, a DrawIO subscription, or any external service. The only requirement is that **ZenUML for Confluence** is installed in your Atlassian Confluence Cloud instance — available free on the Atlassian Marketplace.
+
+### Can multiple people edit the same DrawIO diagram?
+
+Yes, in the same way that any Confluence page content can be edited by multiple people. When a user opens the DrawIO editor and saves, the new version becomes the current state of the diagram on the page. Confluence's built-in **version history** keeps every previous save, so earlier states can be reviewed and restored at any time. Note: simultaneous real-time co-editing (multiple cursors in the same DrawIO canvas at the same moment) is not supported — edits are sequential, last save wins.
+
+### How do I export a DrawIO diagram from Confluence?
+
+- **From the page viewer** — click the diagram to open the fullscreen viewer and use the Export button to download a **PNG or PDF** of the rendered diagram.
+- **From inside the DrawIO editor** — use **File > Export As** to export in DrawIO XML, SVG, PNG, PDF, or HTML format. The XML export gives you a `.drawio`-compatible file you can open in diagrams.net or the DrawIO desktop app.
+
+[View full FAQ →](/confluence/faq/)
+
+## Add DrawIO diagrams to your Confluence space today
+
+Install ZenUML for Confluence free from the Atlassian Marketplace. DrawIO, sequence diagrams, Mermaid, PlantUML, and OpenAPI — all in one app. No server setup, no external accounts.
+
+[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [Compare plans](/confluence/pricing/)
+
+1,000+
+
+Confluence installs
+
+4.8 ★
+
+Marketplace rating
+
+6
+
+Diagram types in one app
+
+Free
+
+Lite plan — no credit card

--- a/src/pages/confluence/diagram-types/drawio.md
+++ b/src/pages/confluence/diagram-types/drawio.md
@@ -19,7 +19,7 @@ Part of ZenUML for Confluence  ·  6 diagram types, one app
 
 Create flowcharts, network diagrams, org charts, and any visual diagram using the open-source DrawIO engine — embedded directly into Confluence Cloud. No DrawIO account, no external tool, no copy-pasting images.
 
-[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [All Diagram Types](/confluence/diagram-types/)
+[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [All Diagram Types](/confluence/diagram-types/)
 
 ✓ Powered by the diagrams.net open-source engine ✓ No DrawIO account required ✓ Import existing .drawio files ✓ Renders in-browser — private by design
 
@@ -174,7 +174,7 @@ Yes, in the same way that any Confluence page content can be edited by multiple 
 
 Install ZenUML for Confluence free from the Atlassian Marketplace. DrawIO, sequence diagrams, Mermaid, PlantUML, and OpenAPI — all in one app. No server setup, no external accounts.
 
-[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [Compare plans](/confluence/pricing/)
+[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) · [Compare plans](/confluence/pricing/)
 
 1,000+
 

--- a/src/pages/confluence/diagram-types/index.md
+++ b/src/pages/confluence/diagram-types/index.md
@@ -17,7 +17,7 @@ unlisted: false
 
 ZenUML for Confluence covers every diagramming need your engineering and documentation team has — sequence diagrams, flowcharts, UML, API specs, and more — from a single Forge app installation. No switching tools, no pasting images, no external accounts.
 
-[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [See All Features](/confluence/features/)
+[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [See All Features](/confluence/features/)
 
 ✓ All 6 types on the free Lite plan ✓ All rendering in-browser — private by design ✓ One macro, one picker — choose the type on insert
 
@@ -177,6 +177,6 @@ Yes. The **Embed** type lets you select any existing diagram stored in a Conflue
 
 Install ZenUML for Confluence once from the Atlassian Marketplace and every diagram type is immediately available from the same macro — no configuration, no external accounts.
 
-[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [Compare plans](/confluence/pricing/)
+[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) · [Compare plans](/confluence/pricing/)
 
 Rated 4.8★ on Atlassian Marketplace  ·  1,000+ installs  ·  Published by **P&D VISION**

--- a/src/pages/confluence/diagram-types/index.md
+++ b/src/pages/confluence/diagram-types/index.md
@@ -1,0 +1,182 @@
+---
+title: Diagram types — 6 formats in one Confluence app
+description: 'Sequence, Mermaid, PlantUML, DrawIO, OpenAPI and Embed — six diagram types from a single Confluence macro. Pick the format that fits the document.'
+keywords:
+  [
+    confluence diagram types,
+    uml diagrams confluence,
+    flowchart confluence,
+    confluence architecture diagram,
+    diagram formats confluence,
+    confluence macro diagram,
+  ]
+unlisted: false
+---
+
+# 6 Diagram Types in One Confluence App
+
+ZenUML for Confluence covers every diagramming need your engineering and documentation team has — sequence diagrams, flowcharts, UML, API specs, and more — from a single Forge app installation. No switching tools, no pasting images, no external accounts.
+
+[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [See All Features](/confluence/features/)
+
+✓ All 6 types on the free Lite plan ✓ All rendering in-browser — private by design ✓ One macro, one picker — choose the type on insert
+
+## Choose the Right Diagram Type
+
+Each type targets a different authoring workflow. Pick the one that fits your diagram — or mix types across Confluence pages freely.
+
+## Sequence Diagrams
+
+Write UML 2.5.1-compliant sequence diagrams in **ZenUML DSL** — a concise, readable text syntax. Live preview updates as you type. AI-assisted generation included. Ideal for teams who want diagrams that live alongside code.
+
+- REST and gRPC API call flows
+- Microservice interaction documentation
+- Authentication and authorization sequences
+- System design and architecture reviews
+
+[Learn more →](/confluence/diagram-types/sequence-diagrams/)
+
+## Mermaid
+
+Full **Mermaid.js** support for the widest variety of diagram subtypes in a single text syntax. Write Mermaid directly in Confluence without any external tool or service — the renderer runs entirely in the browser.
+
+- Flowcharts and process diagrams
+- Class diagrams and ER diagrams
+- Gantt charts and project timelines
+- State machines and pie charts
+
+[Learn more →](/confluence/diagram-types/mermaid/)
+
+## DrawIO / Flowcharts
+
+The full **DrawIO drag-and-drop editor** embedded inside Confluence as a fullscreen modal. No separate DrawIO account or subscription required — diagrams are stored as Confluence custom content and rendered inline on your pages.
+
+- General-purpose flowcharts and process maps
+- Network and infrastructure diagrams
+- Org charts and team structures
+- Wireframes and system overviews
+
+[Learn more →](/confluence/diagram-types/drawio/)
+
+## PlantUML
+
+Render **PlantUML** diagrams from text syntax directly in Confluence. Paste existing PlantUML code or write new diagrams in the editor — live preview, version history, and copy-to-clipboard included.
+
+- Class diagrams and inheritance hierarchies
+- Component and deployment diagrams
+- Activity and state diagrams
+- Use-case diagrams for requirements
+
+[Learn more →](/confluence/diagram-types/plantuml/)
+
+## OpenAPI / Swagger
+
+Paste an **OpenAPI 3.0 or Swagger 2.0** specification in YAML or JSON and get an interactive **Swagger UI** rendered directly on the Confluence page — endpoint explorer, request schemas, and response bodies, all without leaving Confluence.
+
+- API reference documentation embedded in Confluence
+- Keeping specs co-located with architecture decisions
+- Review and onboarding for new API consumers
+- Internal developer portals built on Confluence
+
+[Learn more →](/confluence/diagram-types/openapi/)
+
+## Embed
+
+Reference an existing ZenUML sequence diagram, DrawIO flowchart, or OpenAPI spec stored on another Confluence page. Every page that embeds the diagram automatically renders the **latest saved version** — single source of truth, zero copy-paste drift.
+
+- Reusing a master architecture diagram across multiple docs
+- Linking a shared API spec from several team pages
+- Surfacing a central component diagram in sub-space pages
+- Keeping onboarding docs in sync with design evolution
+
+[How it works ↓](#faq)
+
+## Which Diagram Type Should I Use?
+
+Use this table as a quick reference. When multiple types fit, prefer diagram-as-code (ZenUML, Mermaid, PlantUML) for text that needs to stay in sync with code, and DrawIO for visual layouts that benefit from spatial arrangement.
+
+| I need to document… | Best type | Also works | Why |
+|---|---|---|---|
+| API call sequences between services | ZenUML Sequence | Mermaid sequence | ZenUML DSL is the most concise syntax for request/response flows; live preview makes iteration fast |
+| A decision or process flowchart | Mermaid | DrawIO | Mermaid `flowchart` diagrams render branching logic cleanly from text; DrawIO if visual layout precision matters |
+| Object model or class hierarchy | PlantUML | Mermaid classDiagram | PlantUML class syntax is the most complete for full UML class notation (visibility, stereotypes, notes) |
+| Network topology or infrastructure layout | DrawIO | PlantUML deployment | DrawIO's shape library covers network icons; spatial placement is clearer for topology than text syntax |
+| REST or OpenAPI endpoint reference | OpenAPI / Swagger | — | Interactive Swagger UI gives consumers a try-it-out explorer; no equivalent in other types |
+| Project schedule or roadmap | Mermaid | DrawIO | Mermaid `gantt` type renders timelines directly from text date ranges |
+| Database entity-relationship model | Mermaid | PlantUML | Mermaid `erDiagram` is concise and renders relationship cardinalities clearly |
+| Reusing a diagram from another page | Embed | — | Embed always shows the latest version of the source diagram; no manual copy needed |
+| Org chart or team structure | DrawIO | Mermaid | DrawIO's drag-and-drop layout is more practical for visual hierarchies with photos or color coding |
+| State machine or event-driven flow | PlantUML | Mermaid stateDiagram | PlantUML state syntax supports nested states, concurrent regions, and guards with clear notation |
+
+## Diagram as Code vs. Visual Editing
+
+ZenUML for Confluence deliberately supports both authoring philosophies. Understanding the trade-offs helps you pick the right type for each diagram.
+
+✍️
+
+### Diagram as Code
+
+**Types: ZenUML, Mermaid, PlantUML** You write plain text using a diagram-specific syntax. The renderer converts that text into an SVG diagram at render time.
+
+- Source is stored as plain text — readable, searchable, copyable
+- Diffs are meaningful: changing a line in the spec changes a line in the diagram source
+- Works well with copy-to-clipboard and AI generation: the AI outputs text you paste straight in
+- Version history is human-readable — you can see exactly what changed between saves
+- Faster for complex repeating structures (large sequence diagrams, many classes) because you type rather than drag
+- Trade-off: layout is auto-computed — you cannot freely position individual elements
+
+🖱️
+
+### Visual Editing
+
+**Type: DrawIO** You drag, drop, and connect shapes on a canvas. The diagram data is stored as an XML representation of the canvas state.
+
+- Precise spatial control — place every element exactly where you want it
+- Rich shape library — network icons, AWS/Azure shapes, BPMN, org chart templates
+- No syntax to learn — accessible to non-engineers and less technical writers
+- Ideal for diagrams where visual layout conveys meaning (topology, floor plans, org charts)
+- Works in the same ZenUML macro and Confluence page — same install, same export, same version history
+- Trade-off: bulk updates require manual repositioning; not trivially diffable as text
+
+**Practical recommendation:** Use diagram-as-code (ZenUML, Mermaid, PlantUML) for diagrams that need to stay in sync with code changes — API flows, data models, state machines. Use DrawIO for diagrams where visual positioning and custom iconography are the primary value — infrastructure maps, network topologies, org charts. Use Embed to reuse either type across multiple pages without duplicating the source.
+
+## Frequently Asked Questions
+
+Common questions about diagram types in ZenUML for Confluence.
+
+### How many diagram types does ZenUML for Confluence support?
+
+- **ZenUML Sequence** — text-based UML 2.5.1 sequence diagrams in ZenUML DSL
+- **Mermaid** — full Mermaid.js syntax: flowcharts, Gantt, ER, class, state, sequence, pie
+- **DrawIO / Flowcharts** — drag-and-drop canvas using the DrawIO engine
+- **PlantUML** — class, component, deployment, activity, state, and use-case diagrams
+- **OpenAPI / Swagger** — interactive rendering of OpenAPI 3.x and Swagger 2.0 specs
+- **Embed** — reference an existing diagram from another Confluence page as a live embed
+
+### What is the difference between diagram-as-code and visual diagramming?
+
+**Diagram-as-code** (ZenUML, Mermaid, PlantUML) means writing your diagram in a text syntax — the renderer computes the layout and produces the visual output. The source is plain text, which makes it easy to version, diff, copy, and generate with AI. **Visual diagramming** (DrawIO) means dragging and dropping shapes on a canvas, then connecting them manually. You control the exact position of every element. This is better for diagrams where spatial layout itself conveys meaning — network topologies, org charts, floor plans. Both approaches store diagrams as Confluence custom content and render in the browser. Both are part of the same ZenUML macro.
+
+### Which diagram type should I use for API documentation?
+
+- **API endpoint reference** (routes, parameters, request/response schemas) — use **OpenAPI / Swagger**. Paste your OpenAPI 3.x or Swagger 2.0 YAML/JSON and get an interactive Swagger UI explorer directly on the Confluence page.
+- **API call sequence** (who calls whom, in what order) — use **ZenUML Sequence** or **Mermaid sequence**. Both render clear actor-to-actor message flows.
+
+### Can I use the Embed type to reuse a diagram across multiple pages?
+
+Yes. The **Embed** type lets you select any existing diagram stored in a Confluence page (in the same space or another space you have access to) and display it on the current page. The embed always renders the **latest saved version** of the source diagram — you update the original once and every embedding page automatically reflects the change. This is the recommended approach for shared component diagrams, master architecture diagrams, and canonical API specs that multiple teams reference.
+
+### Do all six diagram types work on the free Lite plan?
+
+- **Lite (free)** — up to 100 diagrams per space, all six types
+- **Full (paid)** — unlimited diagrams across all spaces, all six types
+
+[View full FAQ →](/confluence/faq/)
+
+## All Six Types — One Install
+
+Install ZenUML for Confluence once from the Atlassian Marketplace and every diagram type is immediately available from the same macro — no configuration, no external accounts.
+
+[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [Compare plans](/confluence/pricing/)
+
+Rated 4.8★ on Atlassian Marketplace  ·  1,000+ installs  ·  Published by **P&D VISION**

--- a/src/pages/confluence/diagram-types/mermaid.md
+++ b/src/pages/confluence/diagram-types/mermaid.md
@@ -25,7 +25,7 @@ Diagram Types
 
 Write Mermaid.js syntax directly in your Confluence pages and get flowcharts, sequence diagrams, class diagrams, Gantt charts, ER diagrams, and more — rendered live in the browser, stored as text, and version-controlled alongside your documentation.
 
-[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [All Diagram Types](/confluence/diagram-types/)
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) · [All Diagram Types](/confluence/diagram-types/)
 
 About Mermaid
 
@@ -193,4 +193,4 @@ Get started for free
 
 Install ZenUML for Confluence from the Atlassian Marketplace — free, no credit card required. Write your first Mermaid diagram in under two minutes.
 
-[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [See All Diagram Types](/confluence/diagram-types/)
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) · [See All Diagram Types](/confluence/diagram-types/)

--- a/src/pages/confluence/diagram-types/mermaid.md
+++ b/src/pages/confluence/diagram-types/mermaid.md
@@ -1,0 +1,196 @@
+---
+title: Mermaid diagrams in Confluence Cloud
+description: 'Render Mermaid flowcharts, sequence diagrams, Gantt charts, ER and class diagrams directly on a Confluence page. No external renderer, no image uploads.'
+keywords:
+  [
+    mermaid confluence,
+    mermaid for confluence,
+    confluence mermaid macro,
+    mermaid flowchart confluence,
+    mermaid gantt confluence,
+    mermaid diagram plugin,
+  ]
+unlisted: false
+---
+
+1. [Home](/confluence/)
+2. ›
+3. [Diagram Types](/confluence/diagram-types/)
+4. ›
+5. Mermaid
+
+Diagram Types
+
+# Mermaid Diagrams in Confluence
+
+Write Mermaid.js syntax directly in your Confluence pages and get flowcharts, sequence diagrams, class diagrams, Gantt charts, ER diagrams, and more — rendered live in the browser, stored as text, and version-controlled alongside your documentation.
+
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [All Diagram Types](/confluence/diagram-types/)
+
+About Mermaid
+
+## What is Mermaid?
+
+Mermaid is an open-source JavaScript library that generates diagrams from a plain-text definition language. You write a short, human-readable description — similar to Markdown — and Mermaid renders a fully styled diagram directly in the browser, with no image files and no server required.
+
+Mermaid is widely adopted across the developer toolchain. GitHub renders Mermaid code blocks natively in READMEs and pull request descriptions. GitLab, Notion, and many documentation platforms do the same. When you write a diagram as Mermaid source code, it becomes a first-class text artifact: reviewable in a code review, diffable in version control, and portable across every tool that speaks Mermaid.
+
+ZenUML for Confluence brings the same Mermaid.js library into your Atlassian workspace. Paste a diagram you drafted in a GitHub README, write one from scratch in the live editor, or let AI generate a starting draft — all within the page you are already editing.
+
+Live Example
+
+## Mermaid syntax at a glance
+
+The code below is a complete Mermaid flowchart. Paste it into a ZenUML macro set to the Mermaid type and it renders immediately — no configuration required.
+
+This syntax is identical to what you would write in a GitHub README fenced code block — no changes required when moving between tools.
+
+Supported Types
+
+## Supported Mermaid diagram types
+
+ZenUML for Confluence supports eleven Mermaid diagram types, covering the full range of software architecture, data modelling, project management, and analytics use cases.
+
+### flowchart / graph
+
+Directed and undirected flowcharts with decision nodes, subgraphs, and custom shapes.
+
+### sequence
+
+Participant-based sequence diagrams with messages, loops, alt/opt blocks, and notes.
+
+### class
+
+UML class diagrams with attributes, methods, inheritance, and association relationships.
+
+### stateDiagram
+
+State machine diagrams with transitions, composite states, and concurrency forks.
+
+### erDiagram
+
+Entity-relationship diagrams with cardinality notations — ideal for documenting database schemas.
+
+### gantt
+
+Gantt charts with sections, tasks, durations, dependencies, and milestone markers.
+
+### pie
+
+Pie charts with labelled slices — useful for showing distribution and proportions at a glance.
+
+### journey
+
+User journey maps that plot tasks by actor and satisfaction score across a defined timeline.
+
+### gitgraph
+
+Git branch-and-commit graphs — useful for documenting branching strategies in engineering wikis.
+
+### quadrantChart
+
+Two-axis quadrant charts for plotting items by two dimensions — prioritisation, risk, or effort.
+
+### xychart
+
+Bar and line charts on x/y axes — for visualising metrics, trends, and time-series data inline.
+
+Benefits
+
+## Why use Mermaid in Confluence?
+
+1
+
+### Same syntax as GitHub and GitLab
+
+Engineers who already write Mermaid in pull request descriptions and README files can paste that exact code into Confluence without any translation. There is no new syntax to learn and no format conversion step.
+
+2
+
+### Diagrams that live next to the docs
+
+Because the diagram source is plain text stored in Confluence custom content, it lives on the same page as the documentation that references it. No switching to Lucidchart, no managing file attachments, no broken image links when files move.
+
+3
+
+### Browser-only rendering — your data stays local
+
+Mermaid.js renders entirely in the visitor's browser. Diagram source code is never sent to ZenUML servers or any third-party rendering service during the display process. This matters for teams with strict data residency requirements.
+
+4
+
+### Version-controllable architecture documentation
+
+Text-based diagrams integrate naturally with a "docs as code" workflow. Store the Mermaid source in your repository, review diagram changes in pull requests, and keep the Confluence page in sync by pasting updated code — no export/import loop.
+
+5
+
+### Live preview eliminates save-to-check cycles
+
+The ZenUML editor renders the diagram in real time as you type. Syntax errors surface inline before you save. You never have to publish a page just to check whether your flowchart looks correct.
+
+Use Cases
+
+## Who uses Mermaid in Confluence — and how
+
+Developers
+
+### Documenting system architecture
+
+Engineering teams use `flowchart` and `class` diagrams to document microservice boundaries, dependency graphs, and component relationships alongside their design documents — updating diagrams in the same PR that changes the code.
+
+Architects
+
+### Modelling database schemas
+
+Solutions architects use `erDiagram` to capture entity-relationship models in Confluence, giving product managers and QA engineers a readable view of the database schema without requiring access to a database tool or migration files.
+
+Developers
+
+### Explaining Git branching strategies
+
+Platform and DevOps teams use `gitgraph` to illustrate branching models (GitFlow, trunk-based development, release branches) in onboarding wikis so new engineers can visualise the workflow before touching the repository.
+
+Product Managers
+
+### Mapping user journeys and feature flows
+
+PMs use `journey` and `flowchart` diagrams to sketch user flows and satisfaction maps in product specification pages, giving designers and engineers a shared reference without importing assets from a separate design tool.
+
+Project Managers
+
+### Tracking project timelines with Gantt charts
+
+Project leads use `gantt` diagrams to embed lightweight project timelines directly in Confluence milestone pages. The plain-text format means any team member can update a task duration or add a dependency without needing a separate PM tool.
+
+FAQ
+
+## Frequently asked questions
+
+### What Mermaid diagram types are supported in ZenUML for Confluence?
+
+ZenUML for Confluence supports eleven Mermaid diagram types: **flowchart**, **sequence**, **class**, **stateDiagram**, **erDiagram**, **gantt**, **pie**, **journey**, **gitgraph**, **quadrantChart**, and **xychart**. This covers all of the most commonly used Mermaid diagram types available in the Mermaid.js library.
+
+### Is Mermaid syntax the same as GitHub Markdown?
+
+Yes. ZenUML for Confluence uses the same Mermaid.js library that GitHub, GitLab, and Notion use to render fenced Mermaid code blocks. A diagram that renders in a GitHub README will render identically in Confluence using ZenUML — no syntax changes required. The only difference is that in Confluence you paste the diagram body into the ZenUML macro editor rather than wrapping it in a fenced code block.
+
+### Can I copy a Mermaid diagram from GitHub into Confluence?
+
+Yes. Copy the Mermaid source code from your GitHub README or pull request (excluding the opening and closing backtick fences and the `mermaid` language tag), paste it into a ZenUML macro set to the Mermaid type, and it will render immediately. The syntax is identical — there is no translation step. This also works in reverse: a diagram you draft in Confluence can be pasted directly into a GitHub Markdown file.
+
+### How do I create a flowchart in Confluence?
+
+Insert a ZenUML macro on your Confluence page, select the Mermaid diagram type in the editor, and type your flowchart using Mermaid's `graph` or `flowchart` syntax. A minimal example: `graph TD  A[Start] --> B{Decision}  B -- Yes --> C[Action]  B -- No --> D[End]` The diagram renders live as you type. When you are satisfied, publish the page and the rendered flowchart is visible to all page viewers without any plugin or export step.
+
+### Does Mermaid support ER diagrams and database schemas?
+
+Yes. The `erDiagram` type in Mermaid lets you define entities, attributes, and relationships — one-to-one, one-to-many, and many-to-many — using a simple text syntax. For example: `CUSTOMER ||--o{ ORDER : "places"` defines a one-to-many relationship between a customer and their orders. ZenUML for Confluence renders `erDiagram` fully in the browser, with no server-side processing. It is well suited for documenting database schemas directly alongside your Confluence architecture and API design pages.
+
+Get started for free
+
+## Add Mermaid diagrams to Confluence today
+
+Install ZenUML for Confluence from the Atlassian Marketplace — free, no credit card required. Write your first Mermaid diagram in under two minutes.
+
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [See All Diagram Types](/confluence/diagram-types/)

--- a/src/pages/confluence/diagram-types/openapi.md
+++ b/src/pages/confluence/diagram-types/openapi.md
@@ -1,0 +1,171 @@
+---
+title: OpenAPI and Swagger docs in Confluence
+description: 'Render an OpenAPI or Swagger specification as browsable API documentation on a Confluence page. The spec stays in the page and stays current.'
+keywords:
+  [
+    openapi confluence,
+    swagger confluence,
+    api documentation confluence,
+    confluence swagger macro,
+    openapi spec confluence,
+    rest api docs confluence,
+  ]
+unlisted: false
+---
+
+1. [Home](/confluence/)
+2. ›
+3. [Diagram Types](/confluence/diagram-types/)
+4. ›
+5. OpenAPI
+
+OpenAPI & Swagger
+
+# Interactive API Docs in Confluence — OpenAPI & Swagger
+
+Paste an OpenAPI 3.0 or Swagger 2.0 specification into a Confluence macro and it renders as a fully interactive Swagger UI — browse endpoints, expand schemas, and test calls without leaving your Confluence page.
+
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [All Diagram Types](/confluence/diagram-types/)
+
+What is it?
+
+## What is the OpenAPI viewer?
+
+The ZenUML OpenAPI viewer is a Confluence macro that accepts an **OpenAPI or Swagger specification** written in YAML or JSON and renders it as an interactive [Swagger UI](https://swagger.io/tools/swagger-ui/) directly on the page. Readers can expand endpoints, read request and response schemas, view example payloads, and — when a backend is reachable — send live test requests, all from inside Confluence.
+
+The spec is stored as plain text in Confluence custom content. Rendering happens entirely in the browser using the Swagger UI library — your API specification never leaves your Confluence instance during the rendering process. There is no external API documentation hosting service involved, and no ZenUML server receives the spec content.
+
+The viewer is one of six diagram types bundled in a single ZenUML for Confluence installation. It is available in both the **free Lite plan** and the paid Full plan with no difference in OpenAPI functionality between the two.
+
+Supported Formats
+
+## OpenAPI 3.0, Swagger 2.0, JSON, YAML
+
+The viewer accepts all common OpenAPI and Swagger specification formats. Paste whichever format your toolchain already produces — no conversion step is required.
+
+OpenAPI 3.0 / 3.1
+
+Swagger 2.0
+
+YAML
+
+JSON
+
+### OpenAPI 3.x
+
+The current OpenAPI Specification standard. Supports `components`, `requestBody`, multiple server URLs, and link objects. ZenUML renders OpenAPI 3.0 and 3.1 documents.
+
+### Swagger 2.0
+
+The widely-used predecessor to OpenAPI 3.x. If your existing toolchain generates Swagger 2.0 JSON or YAML, paste it as-is — the viewer handles it without any migration.
+
+### YAML or JSON
+
+Both serialisation formats are accepted. YAML is the more readable choice for hand-authored specs; JSON integrates cleanly with code-generation tools. Either format renders identically in Swagger UI.
+
+Example
+
+## A minimal OpenAPI spec in Confluence
+
+Paste any valid OpenAPI YAML or JSON directly into the ZenUML macro editor. The snippet below is a self-contained example — copy it into the editor to see the Swagger UI rendered on your page.
+
+openapi: "3.0.3" info: title: Petstore API version: "1.0.0" description: A sample API for demonstration purposes servers: - url: https://petstore.example.com/v1 paths: /pets: get: summary: List all pets operationId: listPets parameters: - name: limit in: query schema: type: integer responses: "200": description: A list of pets post: summary: Create a pet operationId: createPet requestBody: required: true content: application/json: schema: $ref: "#/components/schemas/Pet" responses: "201": description: Pet created components: schemas: Pet: type: object required: [id, name] properties: id: type: integer name: type: string
+
+The rendered Swagger UI shows collapsible endpoint sections, parameter tables, request body schemas, response codes, and a "Try it out" panel — all generated from the spec text above.
+
+Who is this for?
+
+## API developers, technical writers, and platform teams
+
+Any team that maintains API documentation benefits from keeping specs in Confluence alongside the rest of their technical documentation.
+
+### API Developers
+
+Paste your spec into a Confluence page and share a readable, interactive API reference with your teammates — without setting up a separate Swagger UI hosting environment. When the spec changes, update the macro content and republish.
+
+### Technical Writers
+
+Keep the canonical API spec on the same Confluence page as the narrative documentation, ADRs, and usage guides. Readers see both the reference and the context in one place, with no link-jumping to an external tool.
+
+### Platform & Integration Teams
+
+Document internal APIs and integration contracts in the same Confluence spaces where implementation notes and runbooks live. Consumers can explore the spec interactively and test endpoints against staging without switching tools.
+
+Use Cases
+
+## Four ways teams use the OpenAPI viewer
+
+From internal microservices to public developer portals, the viewer fits wherever your API documentation needs to live close to your team's work.
+
+01
+
+### Internal microservice contracts
+
+Engineering teams document internal REST APIs in the Confluence spaces where sprint plans and architecture decision records live. When a service adds a new endpoint or changes a response schema, the spec is updated in the macro and the page re-published. All consumers see the latest spec — formatted, searchable, and interactive — on the same page they already bookmark.
+
+02
+
+### API design review in Confluence
+
+Before implementation begins, API designers share a draft spec on a Confluence design doc. Stakeholders explore the proposed endpoints in Swagger UI, leave inline Confluence comments on specific fields, and flag breaking changes — all within the page. Iteration happens on the spec text rather than on a static PDF or a screenshot of an external tool.
+
+03
+
+### Runbooks with embedded API reference
+
+Operations and platform teams embed the relevant API spec sections in runbooks and incident response pages. When an on-call engineer responds to an alert, the Swagger UI is right there on the runbook page — they can read parameters, check response codes, and test calls against a staging endpoint without opening a separate tab.
+
+04
+
+### Partner and integration documentation
+
+Teams that share APIs with external partners or other internal divisions publish the spec on a Confluence space shared with those audiences. The interactive Swagger UI gives consumers a self-service reference experience without requiring a dedicated developer portal or external hosting infrastructure.
+
+Comparison
+
+## OpenAPI viewer vs. other API documentation tools
+
+ZenUML's OpenAPI viewer is not a replacement for purpose-built API portals — it solves a different problem: keeping your spec readable and interactive inside the Confluence workspace where your team's documentation already lives.
+
+| Dimension | ZenUML OpenAPI viewer in Confluence | Standalone Swagger UI self-hosted | API portals e.g. Stoplight, Readme |
+|---|---|---|---|
+| **Where it lives** | Inside a Confluence page, next to your team docs | Separate URL, separate infrastructure | External SaaS portal, separate login |
+| **Spec storage** | Confluence custom content (version-controlled) | File system or environment variable | Proprietary platform storage |
+| **Rendering** | In-browser, Swagger UI — spec never leaves Confluence | In-browser, Swagger UI | Cloud-rendered, vendor-hosted |
+| **Infrastructure needed** | None — included in the Confluence macro | A server or container to host the app | Vendor subscription |
+| **Context alongside spec** | Full Confluence page content — ADRs, guides, diagrams | None (standalone app) | Guides supported, separate from org docs |
+| **Audience** | Teams already working in Confluence | Internal developers with server access | External developers, large API products |
+
+If you need a polished public developer portal with custom branding, versioning across many releases, and a dedicated consumer sign-up flow, a purpose-built API portal is the right tool. If you need your API spec to be readable and testable where your engineers and writers already work, the ZenUML OpenAPI viewer is the lower-friction choice.
+
+FAQ
+
+## Frequently asked questions
+
+### What OpenAPI versions does ZenUML support?
+
+ZenUML for Confluence supports **OpenAPI 3.0** (and 3.1) and **Swagger 2.0** specifications. Both YAML and JSON formats are accepted. Paste the spec directly into the macro editor — no file upload or conversion step required.
+
+### Can I test API endpoints from Confluence with ZenUML?
+
+The Swagger UI rendered by ZenUML includes the "Try it out" panel for each endpoint. Whether live requests succeed depends on whether your API backend is accessible from the browser and whether CORS is configured to allow the request origin. ZenUML itself does not proxy or restrict the requests — the browser sends them directly to the URL defined in the spec's `servers` field.
+
+### Does the OpenAPI viewer support authentication headers in Swagger UI?
+
+Yes. Swagger UI renders the **Authorize button** and auth dialogs defined in your spec's `securitySchemes` — including HTTP Basic, Bearer tokens, API keys, and OAuth 2.0 flows. Users can enter credentials in Swagger UI's auth dialog and they will be included in "Try it out" requests. Credentials are held in browser memory only and are not persisted by ZenUML.
+
+### How do I keep my OpenAPI spec updated in Confluence?
+
+Edit the macro and paste the updated spec into the editor, then publish the Confluence page. Each save creates a new Confluence custom content version, so the full edit history is preserved and any past spec version can be restored. For teams using CI/CD, the Confluence REST API can be used to update page content programmatically — the spec lives as plain text, making automation straightforward.
+
+### Can I embed an OpenAPI spec from a URL?
+
+The ZenUML OpenAPI viewer requires the spec to be **pasted directly into the macro editor** — it does not fetch specs from an external URL at render time. This keeps the rendering fully in-browser and avoids exposing internal API URLs or requiring outbound network access from the viewer. If your spec is hosted externally, copy its content into the macro editor and update it manually when the spec changes.
+
+Get started for free
+
+## Embed your first API spec in Confluence today
+
+ZenUML Lite is free on the Atlassian Marketplace — no credit card, no external accounts. The OpenAPI viewer is included in the free plan alongside five other diagram types.
+
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [All Diagram Types](/confluence/diagram-types/)

--- a/src/pages/confluence/diagram-types/openapi.md
+++ b/src/pages/confluence/diagram-types/openapi.md
@@ -25,7 +25,7 @@ OpenAPI & Swagger
 
 Paste an OpenAPI 3.0 or Swagger 2.0 specification into a Confluence macro and it renders as a fully interactive Swagger UI — browse endpoints, expand schemas, and test calls without leaving your Confluence page.
 
-[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [All Diagram Types](/confluence/diagram-types/)
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) · [All Diagram Types](/confluence/diagram-types/)
 
 What is it?
 
@@ -168,4 +168,4 @@ Get started for free
 
 ZenUML Lite is free on the Atlassian Marketplace — no credit card, no external accounts. The OpenAPI viewer is included in the free plan alongside five other diagram types.
 
-[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [All Diagram Types](/confluence/diagram-types/)
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) · [All Diagram Types](/confluence/diagram-types/)

--- a/src/pages/confluence/diagram-types/plantuml.md
+++ b/src/pages/confluence/diagram-types/plantuml.md
@@ -19,7 +19,7 @@ unlisted: false
 
 Write PlantUML syntax directly inside a Confluence macro. Class diagrams, component diagrams, deployment, activity, state, and more — rendered live in the browser, stored as text, private by design.
 
-[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [All Diagram Types](/confluence/diagram-types/)
+[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [All Diagram Types](/confluence/diagram-types/)
 
 ✓ Same syntax as your IDE plugins ✓ No server-side rendering — stays in Confluence ✓ Version-controlled text diagrams
 
@@ -166,6 +166,6 @@ On any Confluence page, type `/ZenUML` or use the macro picker. Select **PlantUM
 
 Paste your existing `@startuml … @enduml` block into the editor. The diagram renders live as you type. Click Publish to save.
 
-[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [All Diagram Types](/confluence/diagram-types/)
+[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) · [All Diagram Types](/confluence/diagram-types/)
 
 Used by engineering teams at Amazon, ThoughtWorks, and more.  |  Published by **P&D VISION** on Atlassian Marketplace.

--- a/src/pages/confluence/diagram-types/plantuml.md
+++ b/src/pages/confluence/diagram-types/plantuml.md
@@ -1,0 +1,171 @@
+---
+title: PlantUML diagrams in Confluence
+description: 'Render PlantUML class, component, activity, use-case and deployment diagrams in Confluence. Paste existing PlantUML source straight into the editor.'
+keywords:
+  [
+    plantuml confluence,
+    plantuml for confluence,
+    confluence plantuml macro,
+    class diagram confluence,
+    component diagram confluence,
+    activity diagram confluence,
+  ]
+unlisted: false
+---
+
+🌿 PlantUML  ·  Text-based UML  ·  Client-side rendering
+
+# PlantUML Diagrams in Confluence
+
+Write PlantUML syntax directly inside a Confluence macro. Class diagrams, component diagrams, deployment, activity, state, and more — rendered live in the browser, stored as text, private by design.
+
+[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [All Diagram Types](/confluence/diagram-types/)
+
+✓ Same syntax as your IDE plugins ✓ No server-side rendering — stays in Confluence ✓ Version-controlled text diagrams
+
+## What is PlantUML?
+
+PlantUML is an **open-source, text-to-diagram tool** that converts a simple, human-readable syntax into rendered UML and non-UML diagrams. Instead of dragging shapes on a canvas, you describe participants, relationships, and flows in a plain-text block — PlantUML turns that description into a diagram image.
+
+Because the source is plain text, PlantUML diagrams fit naturally into **software development workflows**: store them in Git alongside your code, review changes in pull requests, generate them in CI pipelines, and regenerate them automatically when your architecture changes. This is the approach that software architects and Java-ecosystem teams have been using for over a decade.
+
+PlantUML supports a wide surface of diagram types — from precise UML artefacts like class diagrams and component diagrams to process-oriented views like activity and state diagrams. It is the go-to choice when a team wants a **single text syntax** that covers the full spectrum of UML without switching tools.
+
+## Supported PlantUML Diagram Types
+
+All major PlantUML diagram categories are supported. Write standard `@startuml … @enduml` blocks and the diagram renders live.
+
+| Diagram Type | What it Shows | Typical Use |
+|---|---|---|
+| **Class** | Classes, interfaces, attributes, methods, and relationships (inheritance, composition, dependency) | Domain model, OOP design, API object hierarchy |
+| **Component** | Software components, packages, interfaces, and their dependencies | System architecture, microservice topology, module structure |
+| **Deployment** | Nodes, artifacts, and communication paths across infrastructure | Cloud deployment topology, infrastructure runbooks |
+| **Activity** | Workflow steps, decision branches, parallel paths, and swim lanes | Business processes, CI/CD pipelines, on-call runbooks |
+| **State** | States, transitions, guards, and entry/exit actions | Order lifecycle, auth flows, feature flag state machines |
+| **Use Case** | Actors, use cases, and their relationships within a system boundary | Requirements documentation, stakeholder communication |
+| **Entity Relationship** | Entities, attributes, and cardinality between database tables | Database schema documentation, data model overview |
+| **Timing** | State changes on a shared time axis for multiple participants | Protocol timing, embedded system signal analysis |
+| **Sequence** | Message exchanges between participants over time | API call flows, event-driven interactions |
+
+## PlantUML in Action
+
+The snippet below is a complete PlantUML class diagram. Paste it directly into the ZenUML macro editor — no modifications needed.
+
+PlantUML source
+
+### Package grouping
+
+The `package` keyword groups related classes into a named boundary — useful for bounded-context documentation and microservice domain maps.
+
+### Relationship multiplicity
+
+Arrow syntax expresses association (`-->`), composition (`*--`), and multiplicity labels (`"1"`, `"0..*"`) that map directly to UML 2.x semantics.
+
+### Enums and typing
+
+PlantUML supports `enum` alongside `class` and `interface`, so your full domain vocabulary — including state machines — appears in a single diagram.
+
+## ZenUML DSL vs PlantUML for Sequence Diagrams
+
+ZenUML for Confluence supports both syntaxes. Here is how they differ for sequence diagrams specifically — the diagram type where the choice matters most.
+
+| Dimension | ZenUML DSL | PlantUML |
+|---|---|---|
+| **Syntax style** | Method-call notation — reads like code (`OrderService.placeOrder(cart)`) | Arrow notation — explicit message passing (`Client -> Server: placeOrder(cart)`) |
+| **Conciseness** | More concise for multi-step API flows; nesting and return values implicit | More verbose; every arrow and return must be stated explicitly |
+| **Readability for developers** | Familiar to developers — looks like function calls in any language | Familiar to architects and teams with prior PlantUML experience |
+| **Diagram types** | Sequence diagrams only | Sequence plus eight other diagram types in the same syntax |
+| **UML compliance** | OMG UML 2.5.1 compliant | UML 2.x aligned (community-driven) |
+| **Best for** | Teams whose primary use case is API interaction documentation | Teams that document architecture across multiple UML diagram types |
+| **IDE support** | ZenUML VS Code extension, IntelliJ plugin | PlantUML VS Code extension, IntelliJ PlantUML Integration (widely adopted) |
+
+**Recommendation:** Use ZenUML DSL when your team's primary use case is sequence diagrams for API or service interaction documentation. Use PlantUML when your team already uses PlantUML in their IDE workflow and wants a single syntax for class, component, deployment, and sequence diagrams. Both are available in the same macro — you can mix and match across different Confluence pages.
+
+## Who Uses PlantUML in Confluence
+
+Five common scenarios where engineering teams reach for PlantUML inside Confluence.
+
+### Architecture Decision Records
+
+Software architects embed PlantUML component and deployment diagrams directly in ADR pages. When the decision changes, they update the text source and the diagram updates instantly — no stale PNG exports to hunt down and replace.
+
+### Java Domain Model Documentation
+
+Java and Kotlin teams generate class diagrams from their existing PlantUML IDE plugin annotations and paste them into Confluence. The same `@startuml` block that renders in IntelliJ renders identically in the ZenUML macro.
+
+### Infrastructure Runbooks
+
+SRE and platform teams use PlantUML deployment diagrams on runbook pages to show node topology, service dependencies, and communication paths — keeping the diagram in the same Confluence space as the on-call procedures.
+
+### Business Process Documentation
+
+Business analysts and product managers use PlantUML activity diagrams with swim lanes to model multi-team approval workflows, onboarding processes, and incident escalation paths — without needing access to a separate diagram tool.
+
+### Database Schema Pages
+
+Backend teams use PlantUML entity relationship diagrams on Confluence data-model pages. Schema changes are reviewed as text diffs in pull requests, then the updated PlantUML block is pasted back into Confluence to keep documentation current.
+
+### Already using ZenUML DSL?
+
+ZenUML DSL and PlantUML coexist in the same app. Use ZenUML DSL for your sequence diagrams and PlantUML for everything else — class, component, deployment, and activity diagrams. One Confluence macro, both syntaxes.
+
+## Frequently Asked Questions
+
+Common questions about PlantUML support in ZenUML for Confluence.
+
+### What is PlantUML?
+
+PlantUML is an **open-source, text-to-diagram tool** that converts a simple, human-readable syntax into UML and non-UML diagrams. You describe participants, classes, components, and their relationships in a plain-text block — PlantUML turns that description into a rendered diagram. Because diagrams are plain text, they can be stored in Git, reviewed in pull requests, and regenerated automatically when your system architecture changes. PlantUML has been widely adopted by Java developers, software architects, and teams across the JVM ecosystem for over a decade.
+
+### What PlantUML diagram types does ZenUML for Confluence support?
+
+- **Class diagrams** — classes, interfaces, attributes, methods, and UML relationships
+- **Component diagrams** — software components, packages, and dependencies
+- **Deployment diagrams** — nodes, artifacts, and infrastructure topology
+- **Activity diagrams** — workflow steps, decision branches, and swim lanes
+- **State diagrams** — states, transitions, and guards
+- **Use case diagrams** — actors, use cases, and system boundaries
+- **Entity relationship diagrams** — entities and database cardinality
+- **Timing diagrams** — state changes on a shared time axis
+- **Sequence diagrams** — message exchanges between participants
+
+### How does PlantUML compare to ZenUML DSL for sequence diagrams?
+
+- **ZenUML DSL** uses method-call notation that reads like code — more concise for multi-step API flows and developer-facing interaction docs.
+- **PlantUML** uses arrow notation — explicit, familiar to teams with prior PlantUML experience, and consistent with the other eight PlantUML diagram types.
+
+### Can I copy PlantUML code from my IDE into Confluence?
+
+Yes. ZenUML for Confluence accepts the same **standard PlantUML syntax** that your IDE plugins produce — IntelliJ PlantUML Integration, the VS Code PlantUML extension, or any other tool that generates `@startuml … @enduml` blocks. Paste the source directly into the ZenUML macro editor and it renders immediately. There is no format conversion or image export step. The same source that renders in your IDE renders identically in Confluence.
+
+### Does PlantUML render server-side or client-side in ZenUML?
+
+PlantUML in ZenUML for Confluence renders **entirely client-side in the browser**. Your PlantUML source code is never sent to ZenUML servers or to the public PlantUML render server at plantuml.com. The rendering engine runs inside the Confluence page, scoped to your Atlassian instance. Diagrams are stored as Confluence custom content — plain text, within your instance. This design is important for teams with data residency requirements or confidential architecture diagrams that must not leave the organisation's infrastructure.
+
+[View full FAQ →](/confluence/faq/)
+
+## Add PlantUML to Your Confluence
+
+Install ZenUML for Confluence and start writing PlantUML diagrams directly on your pages. Free Lite plan. No credit card. No external accounts. Installs in under two minutes.
+
+1
+
+### Install from Marketplace
+
+Search for **"ZenUML"** on the Atlassian Marketplace. Choose Lite (free) or Full (paid). Admin permission required.
+
+2
+
+### Insert a ZenUML macro
+
+On any Confluence page, type `/ZenUML` or use the macro picker. Select **PlantUML** as the diagram type in the macro dialog.
+
+3
+
+### Paste your PlantUML code
+
+Paste your existing `@startuml … @enduml` block into the editor. The diagram renders live as you type. Click Publish to save.
+
+[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [All Diagram Types](/confluence/diagram-types/)
+
+Used by engineering teams at Amazon, ThoughtWorks, and more.  |  Published by **P&D VISION** on Atlassian Marketplace.

--- a/src/pages/confluence/diagram-types/sequence-diagrams.md
+++ b/src/pages/confluence/diagram-types/sequence-diagrams.md
@@ -1,0 +1,174 @@
+---
+title: Sequence diagrams in Confluence with ZenUML DSL
+description: 'Write UML 2.5.1 sequence diagrams in Confluence with a readable text syntax. Live preview, syntax highlighting, and diagrams that stay in sync with the page.'
+keywords:
+  [
+    sequence diagram confluence,
+    uml sequence diagram confluence,
+    zenuml dsl,
+    confluence sequence diagram macro,
+    text based sequence diagram,
+    api flow diagram confluence,
+  ]
+unlisted: false
+---
+
+OMG UML 2.5.1 compliant  ·  2-3× more concise than PlantUML  ·  In-browser rendering
+
+# Sequence Diagrams in Confluence with ZenUML
+
+Write sequence diagrams as code directly inside Confluence using ZenUML DSL — a concise, standards-compliant text syntax. No image uploads, no external tools. The diagram renders in the browser in real time from the moment you type.
+
+[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [See the syntax](#code-example)
+
+✓ OMG UML 2.5.1 compliant ✓ 2-3× more concise than PlantUML ✓ Renders in-browser — zero server upload ✓ Free Lite plan — no credit card
+
+## What is a ZenUML Sequence Diagram?
+
+A ZenUML sequence diagram is an **OMG UML 2.5.1-compliant sequence diagram** written in **ZenUML DSL** — a concise text syntax designed specifically for sequence diagrams. Unlike generic UML tools that require a graphical editor, ZenUML lets you write diagrams the same way you write code: as plain text that you can version, diff, review in pull requests, and store alongside your source code.
+
+Inside Confluence, ZenUML sequence diagrams live in a macro on the page. The source text is stored as **Confluence custom content** — it is part of your Atlassian instance, not an external service. On every page view the ZenUML engine (running entirely in the reader's browser) parses the DSL and renders the diagram as an SVG. No content is transmitted to ZenUML servers at any point.
+
+ZenUML DSL models sequence diagrams as **call expressions** — the same mental model developers use when reading or writing code. Participants are inferred automatically from the messages you write, eliminating the boilerplate declarations that PlantUML requires. The result is diagrams that are typically **2-3× shorter** than equivalent PlantUML source while remaining fully UML-compliant.
+
+## ZenUML DSL — a four-message order flow
+
+Participants are inferred from message sources and targets. No declarations, no boilerplate. The `-->` arrow denotes an asynchronous or return message. Dashes render as a dashed line on the diagram.
+
+order-flow.zenuml
+
+✓ 5 lines of source — no boilerplate ✓ Participants auto-inferred ✓ UML 2.5.1 compliant output
+
+## How ZenUML DSL compares to PlantUML
+
+Both syntaxes produce the same sequence diagram. ZenUML DSL removes the delimiter scaffolding, eliminates participant declarations (they are inferred), and uses a call-expression style that reads more like code. The result is typically 2-3× fewer lines for the same diagram.
+
+ZenUML DSL 5 lines
+
+`title Order Flow Client -> OrderService: placeOrder(items) OrderService -> InventoryService: checkStock(items) InventoryService --> OrderService: stockAvailable OrderService --> Client: orderConfirmed`
+
+- ✓ No `@startuml` / `@enduml` delimiters
+- ✓ Participants inferred — no declarations needed
+- ✓ Call-expression style mirrors code semantics
+
+PlantUML (equivalent) 12 lines
+
+`@startuml title Order Flow participant Client participant OrderService participant InventoryService Client -> OrderService : placeOrder(items) OrderService -> InventoryService : checkStock(items) InventoryService --> OrderService : stockAvailable OrderService --> Client : orderConfirmed @enduml`
+
+- ✗ Requires delimiter boilerplate
+- ✗ Must declare every participant explicitly
+- ✗ Spaces around `:` required; ordering sensitive
+
+Note: ZenUML for Confluence also includes a [PlantUML renderer](/confluence/diagram-types/plantuml/) — teams can use both syntaxes in separate macros on the same page and migrate diagrams incrementally.
+
+## When engineering teams reach for sequence diagrams
+
+ZenUML sequence diagrams in Confluence appear wherever teams need to communicate interactions between actors, services, or systems — in design docs, runbooks, and onboarding guides.
+
+### API Documentation
+
+Show request-response flows for REST and GraphQL endpoints alongside the OpenAPI spec. Readers see both the formal contract and the runtime interaction sequence on the same Confluence page.
+
+### Microservice Interactions
+
+Document how services communicate across event queues, RPC calls, and HTTP APIs. Sequence diagrams make async handoffs and retry logic visible in architecture docs without a whiteboard session.
+
+### User Flows
+
+Map user interactions with a frontend through authentication, data loading, and state changes. Product managers and engineers share one artifact that lives in the Confluence design spec.
+
+### System Architecture
+
+Capture the dynamic view of a system alongside static architecture diagrams. Sequence diagrams explain the "how" that component diagrams leave implicit, and they age alongside the code as text in version history.
+
+### Onboarding Flows
+
+Walk new engineers through service boot sequences, auth handshakes, and dependency initialization. A sequence diagram in a Confluence runbook is faster to read than three paragraphs of prose.
+
+### Incident Post-Mortems
+
+Reconstruct a failure timeline as a sequence diagram in the post-mortem page. Show the exact order of calls, timeouts, and retries. The diagram persists in Confluence version history for future reference.
+
+## Built for engineers who write diagrams as code
+
+Every feature in the sequence diagram editor is designed to keep the diagram in sync with the code, the doc, and the team — without leaving Confluence.
+
+### Live Preview
+
+The rendered sequence diagram updates on every keystroke in the split-pane editor. No save cycle, no reload. Syntax errors are highlighted immediately, so you can correct them before publishing.
+
+### PNG & PDF Export
+
+Export any sequence diagram to PNG or PDF from the inline viewer toolbar. Share in Slack, include in slide decks, or attach to a Jira issue — without re-screenshotting. The export is pixel-exact to the on-page rendering.
+
+### Version History
+
+Every publish creates a new Confluence custom content version. Browse previous states, restore an earlier diagram, and audit who changed what and when — using Confluence's native version history, with no extra tooling.
+
+### Fullscreen Editor
+
+Open any sequence diagram in a fullscreen split-pane modal directly from the Confluence page. Code on the left, rendered diagram on the right. Resize panes to focus on either the source or the output.
+
+### Copy Source Code
+
+Copy the ZenUML DSL source to clipboard with one click from the viewer. Store diagrams in a Git repository alongside source code, paste into another Confluence page, or share in a code review.
+
+### AI-Assisted Generation
+
+Describe an interaction flow in natural language and let the AI generate valid ZenUML DSL source. Edit the output directly in the editor — AI produces a starting point, not a final artifact.
+
+### Privacy-First Rendering
+
+The ZenUML rendering engine runs entirely in the browser. Diagram source text — including confidential service names and API flows — is never transmitted to ZenUML servers. Suitable for air-gapped or strict data residency environments.
+
+### Diagram as Code
+
+Source is stored as plain text in Confluence custom content. Store a copy in Git alongside your service code. Diffs are human-readable. Updates take seconds when the architecture changes.
+
+## Frequently Asked Questions
+
+Common questions about ZenUML sequence diagrams in Confluence — syntax, comparison with other tools, export, and supported UML constructs.
+
+### What is ZenUML sequence diagram syntax?
+
+ZenUML DSL is a text-based syntax for writing **OMG UML 2.5.1-compliant sequence diagrams**. It uses a call-expression style that mirrors how developers think about code execution: `Client -> OrderService: placeOrder(items) OrderService --> Client: orderConfirmed` Participants are inferred automatically from messages — no explicit declarations needed. Notes, combined fragments (alt, loop, opt, par), self-calls, and return arrows are all supported. The source is stored as plain text in Confluence custom content and rendered in the browser via the ZenUML engine.
+
+### How does ZenUML DSL compare to PlantUML sequence syntax?
+
+ZenUML DSL is **2-3× more concise** than PlantUML for sequence diagrams. PlantUML requires `@startuml` / `@enduml` delimiters, explicit `participant` declarations for every actor, and spaces around the colon separator. ZenUML infers participants from the messages you write and eliminates boilerplate. A four-message interaction takes 12 lines in PlantUML and 5 in ZenUML DSL. Both syntaxes are supported by ZenUML for Confluence in separate macro types, so teams can run both on the same page and migrate incrementally.
+
+### Can I use Mermaid sequence diagrams in ZenUML for Confluence?
+
+Yes. ZenUML for Confluence includes a full **Mermaid.js renderer** alongside the ZenUML DSL renderer — both in the same app. To use Mermaid sequence syntax, insert a ZenUML macro, choose the **Mermaid** diagram type, and write standard `sequenceDiagram` Mermaid code. The two diagram types coexist on the same page and are managed through the same macro interface. No separate Mermaid app is required.
+
+### How do I document API flows in Confluence?
+
+Insert a ZenUML macro on any Confluence page and choose the **Sequence** type. Write your API interaction in ZenUML DSL — for example: `title Order Flow Client -> OrderService: placeOrder(items) OrderService -> InventoryService: checkStock(items) InventoryService --> OrderService: stockAvailable OrderService --> Client: orderConfirmed` Publish the page and the diagram renders inline for all readers. For REST or GraphQL API contracts, pair the sequence diagram with the [OpenAPI macro](/confluence/diagram-types/openapi/) in the same app — interactive swagger-ui renders alongside the sequence diagram on the same Confluence page.
+
+### Can I export sequence diagrams to PNG?
+
+Yes. Every ZenUML sequence diagram can be exported to **PNG or PDF** directly from the diagram viewer in Confluence. Click the export button in the viewer toolbar, choose PNG or PDF, and download the file. The export uses the in-browser rendered output — what you export is exactly what viewers see on the page. No external service or upload is involved at any step.
+
+### Does ZenUML sequence diagram support actors, notes, and groups?
+
+- **Participants and actors** — named automatically from messages, or declared explicitly
+- **Synchronous messages** — solid arrow (`->`)
+- **Asynchronous / return messages** — dashed arrow (`-->`)
+- **Self-calls** — a participant sending a message to itself
+- **Notes** — over, left of, or right of a participant
+- **Combined fragments** — `alt` (alternatives), `opt` (optional), `loop`, and `par` (parallel)
+- **Nested groups** — fragments inside fragments
+
+## Start writing sequence diagrams in Confluence — free
+
+Install ZenUML Lite in under two minutes. No server setup, no external accounts, no credit card. The free Lite plan supports all diagram types including ZenUML sequence diagrams.
+
+[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+
+1 Find on Marketplace Search "ZenUML" on the Atlassian Marketplace and choose Lite or Full.
+
+2 Click "Get it now" Select your Confluence Cloud site. Atlassian handles the install — no download needed.
+
+3 Type /ZenUML on a page Insert the macro, choose Sequence, write your diagram, and publish.
+
+Used by engineering teams at Amazon, ThoughtWorks, and more.  |  Published by **P&D VISION** on Atlassian Marketplace.  |  Rated 4.8★ on Atlassian Marketplace.

--- a/src/pages/confluence/diagram-types/sequence-diagrams.md
+++ b/src/pages/confluence/diagram-types/sequence-diagrams.md
@@ -19,7 +19,7 @@ OMG UML 2.5.1 compliant  ·  2-3× more concise than PlantUML  ·  In-browse
 
 Write sequence diagrams as code directly inside Confluence using ZenUML DSL — a concise, standards-compliant text syntax. No image uploads, no external tools. The diagram renders in the browser in real time from the moment you type.
 
-[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [See the syntax](#code-example)
+[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [See the syntax](#code-example)
 
 ✓ OMG UML 2.5.1 compliant ✓ 2-3× more concise than PlantUML ✓ Renders in-browser — zero server upload ✓ Free Lite plan — no credit card
 
@@ -163,7 +163,7 @@ Yes. Every ZenUML sequence diagram can be exported to **PNG or PDF** directly fr
 
 Install ZenUML Lite in under two minutes. No server setup, no external accounts, no credit card. The free Lite plan supports all diagram types including ZenUML sequence diagrams.
 
-[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+[Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
 
 1 Find on Marketplace Search "ZenUML" on the Atlassian Marketplace and choose Lite or Full.
 

--- a/src/pages/confluence/faq.md
+++ b/src/pages/confluence/faq.md
@@ -1,0 +1,287 @@
+---
+title: FAQ — ZenUML for Confluence
+description: 'Answers on diagram limits, data privacy, Forge hosting, supported diagram types, exporting, migration from other tools, and billing through Atlassian.'
+keywords:
+  [
+    zenuml confluence faq,
+    confluence diagram app questions,
+    confluence diagram data privacy,
+    forge app data residency,
+    confluence diagram limit,
+    zenuml support,
+  ]
+unlisted: false
+---
+
+[Home](/confluence/) › FAQ
+
+# Frequently Asked Questions
+
+Everything you need to know about installing, using, and getting the most out of ZenUML for Confluence.
+
+[Getting Started](#getting-started) [Diagram Types](#diagram-types) [Pricing & Plans](#pricing) [Features & Usage](#features) [Technical & Privacy](#technical) [Troubleshooting](#troubleshooting)
+
+## Getting Started
+
+### How do I install ZenUML for Confluence?
+
+Open your Confluence Cloud site, go to **Settings → Find new apps** (or visit the [Atlassian Marketplace](https://marketplace.atlassian.com) and search for *ZenUML*). Click **Install** on the ZenUML for Confluence listing.
+
+Confluence will ask you to review and approve the Forge permissions the app requires — these cover reading and writing page content so diagrams can be saved and displayed. Once you approve, the app is active immediately for all users on your site. No server setup or configuration is needed.
+
+### Is ZenUML for Confluence compatible with Confluence Server or Data Center?
+
+ZenUML for Confluence is a **Forge app and runs exclusively on Confluence Cloud**. It is not compatible with Confluence Server or Confluence Data Center.
+
+If your organisation is on Server or Data Center and is planning a migration to Cloud, ZenUML will be available as soon as your Confluence instance is on Cloud. Contact the ZenUML team if you need help planning the transition.
+
+### What is the difference between ZenUML Lite and ZenUML Full?
+
+**ZenUML Lite** is the free tier. It supports all six diagram types (Sequence, Mermaid, DrawIO, PlantUML, OpenAPI, and Embed) but is limited to **100 diagrams per Confluence space**. Once a space reaches that threshold, a paywall prompt appears for new edits.
+
+**ZenUML Full** removes the per-space diagram limit entirely. It is licensed through the Atlassian Marketplace on a per-user-tier pricing model. Both plans receive the same diagram types and features — the only difference is the space-level diagram cap.
+
+### How do I create my first diagram?
+
+While editing any Confluence page, type **/** (forward slash) to open the insert menu and search for *ZenUML* or *Diagram as Code*. Select the diagram type you want — Sequence, Mermaid, DrawIO, PlantUML, or OpenAPI.
+
+The ZenUML editor opens with a starter template. Edit the code on the left side; the rendered diagram updates live on the right. Click **Publish** or **Save** when you are happy with the result. The diagram is embedded in the page and stored as Confluence custom content.
+
+### Can I migrate diagrams from another diagramming tool?
+
+Partially, depending on the source format:
+
+- **DrawIO / diagrams.net:** ZenUML includes a full DrawIO editor, so existing DrawIO XML files can be opened and continued.
+- **Mermaid:** Paste your Mermaid source directly into the Mermaid diagram type — no conversion needed.
+- **PlantUML:** Paste your PlantUML text directly into the PlantUML diagram type.
+- **Image-only diagrams (Lucidchart, Gliffy, Visio):** These cannot be imported. Diagrams stored only as images need to be recreated as code-based diagrams or re-imported into DrawIO.
+
+## Diagram Types
+
+### What is a ZenUML sequence diagram?
+
+A ZenUML sequence diagram describes interactions between participants (people, services, systems) over time using a text-based DSL (domain-specific language). The ZenUML DSL is designed to be more readable and maintainable than traditional UML text formats. For example:
+
+This renders a clean, standards-compliant UML sequence diagram. Because diagrams live as code, they are diffable in version control, reviewable in pull requests, and reproducible from a plain-text source.
+
+### What Mermaid diagram types are supported?
+
+ZenUML for Confluence supports all mainstream Mermaid diagram types, including:
+
+- Flowcharts (graph TD / LR)
+- Sequence diagrams
+- Class diagrams
+- State diagrams
+- Entity relationship (ER) diagrams
+- Gantt charts
+- Pie charts
+- User journey maps
+- Git graph
+- Mind maps
+- Block diagrams
+- Requirement diagrams
+
+The Mermaid renderer is kept up to date with recent Mermaid.js releases. If a specific Mermaid diagram type is not rendering, check whether it is available in the current Mermaid version bundled with the app.
+
+### Can I use DrawIO / diagrams.net in Confluence with ZenUML?
+
+Yes. ZenUML for Confluence includes a fully integrated DrawIO (diagrams.net) editor as the **Graph** diagram type. You get the complete DrawIO canvas — drag-and-drop shapes, AWS, Azure, and GCP shape libraries, network topology shapes, BPMN shapes, and all standard export options — embedded directly in Confluence without leaving the page.
+
+Diagrams are stored as Confluence custom content (not as file attachments), so they remain associated with the page and do not clutter the page's attachment list.
+
+### What PlantUML diagram types does ZenUML support?
+
+ZenUML's PlantUML renderer supports all standard PlantUML diagram types:
+
+- Sequence diagrams
+- Use case diagrams
+- Class diagrams
+- Activity diagrams (both legacy and new beta syntax)
+- Component diagrams
+- State diagrams
+- Object diagrams
+- Deployment diagrams
+- Timing diagrams
+- Mind maps and WBS (work breakdown structure)
+- Network diagrams (nwdiag)
+
+PlantUML diagrams are sent to the PlantUML rendering service to produce an image, which is then displayed in your Confluence page. See the [Technical & Privacy](#technical) section for details on data handling.
+
+### How do I embed an OpenAPI specification in Confluence?
+
+Use the **OpenAPI** diagram type. Insert a ZenUML macro, choose OpenAPI / Swagger, and paste your OpenAPI 3.x or Swagger 2.0 YAML or JSON specification into the editor. ZenUML renders it as an interactive Swagger UI panel directly inside your Confluence page.
+
+Readers can browse endpoints, expand request and response schemas, and review authentication requirements without leaving Confluence. This is particularly useful for API documentation pages, internal developer portals, and architecture decision records.
+
+### Can I embed a diagram from another Confluence page?
+
+Yes. The **Embed** diagram type lets you reference an existing ZenUML, Graph (DrawIO), or OpenAPI macro stored on any other page within the same Confluence site. You provide the source page reference and macro identifier; ZenUML renders the diagram inline on the target page.
+
+When the source diagram is updated on its home page, the embedded copy reflects the change automatically — there is no need to update each page that embeds it. This is ideal for reusing architecture diagrams, data-flow diagrams, or API specs across multiple documentation pages without maintaining duplicate copies.
+
+## Pricing & Plans
+
+### Is ZenUML for Confluence free?
+
+**ZenUML Lite is permanently free with no time limit.** It supports all six diagram types and up to 100 diagrams per Confluence space. No credit card is required.
+
+For teams that need more than 100 diagrams per space, **ZenUML Full** is a paid upgrade available on the Atlassian Marketplace with per-user-tier pricing. A 30-day free trial is available for Full.
+
+### What does the 100-diagram limit mean for Lite?
+
+The Lite plan allows up to **100 ZenUML diagrams to be saved within a single Confluence space**. Once a space reaches 100 diagrams, creating or editing diagrams in that space triggers a soft paywall prompt.
+
+**Existing diagrams are always viewable** — the limit affects saving and editing, not rendering. The limit is per space, so a Confluence site with multiple spaces each gets its own independent 100-diagram allowance. A team with five active spaces can have up to 500 Lite diagrams across the site.
+
+### How do I upgrade from Lite to Full?
+
+Visit the [Atlassian Marketplace](https://marketplace.atlassian.com) listing for ZenUML for Confluence, click **Try it free** or **Buy now**, and follow the standard Atlassian Marketplace checkout. Billing is handled entirely by Atlassian — ZenUML never receives your payment details.
+
+After purchase, the Full plan activates automatically on your Confluence site and the per-space diagram limit is removed. If ZenUML Lite is already installed, you can also trigger the upgrade from **Settings → Manage apps → ZenUML → Upgrade**.
+
+### Does ZenUML charge per user?
+
+ZenUML Full follows the **standard Atlassian Marketplace tier-based pricing model**. You pay a single flat fee based on the number of users at your Confluence site (for example, 1–10 users, 11–25 users, 26–50 users, and so on) — not a per-seat per-month charge for each individual user.
+
+The Lite plan is free for any number of users.
+
+### Is there a free trial for the Full plan?
+
+Yes. The Atlassian Marketplace provides a standard **30-day free trial** for ZenUML Full. During the trial, all Full features are unlocked with no diagram limits across all spaces.
+
+At the end of the trial period, if you do not purchase, the app automatically reverts to Lite plan behaviour. No credit card is required to start the trial — it is initiated through your standard Atlassian Marketplace account.
+
+## Features & Usage
+
+### How do I export a diagram to PNG?
+
+Open the diagram in the ZenUML fullscreen viewer by clicking the **expand / fullscreen icon** on the diagram macro in view mode. In the toolbar, click the **Export** or **Download** button and select PNG. The diagram renders at high resolution and downloads to your computer.
+
+For DrawIO diagrams, the DrawIO editor also offers direct export to PNG, SVG, PDF, HTML, and XML from its own **File → Export as** menu inside the editor.
+
+### Does ZenUML have a fullscreen editor?
+
+Yes. Every diagram type has a fullscreen mode:
+
+- **View mode:** Click the expand icon on any diagram macro to open an immersive fullscreen viewer with zoom, pan, and export controls.
+- **Edit mode:** The ZenUML editor opens as a modal overlay with a **split-pane layout** — code on the left, live preview on the right. You can drag the divider to give more space to either side. The fullscreen button in the editor header expands the entire editor to your full browser viewport.
+
+### Can I see version history for my diagrams?
+
+Diagram content is stored as Confluence custom content attached to the page. Confluence does not currently expose separate version history for custom content the way it does for page body text.
+
+To track diagram history, the recommended approach is to use **Diagram as Code**: because your diagram source is plain text, you can copy it into a code block in the page body. Confluence's page version history then captures how the source changed over time. For teams with strict audit requirements, storing diagram source in a Git repository alongside other code assets is also an option.
+
+### How does Diagram as Code work?
+
+Diagram as Code means your diagram is **defined entirely by a text source** — ZenUML DSL, Mermaid syntax, PlantUML text, or OpenAPI YAML. The text is the single source of truth. ZenUML stores this text and renders it into a visual diagram on demand.
+
+Because the source is plain text you can:
+
+- Version it in Git and diff changes in pull requests
+- Generate diagrams programmatically from code or documentation pipelines
+- Review diagram changes in code review tools before publishing
+- Reproduce the exact same diagram on any machine from the source alone
+
+There is no proprietary binary format that requires a specific tool to open.
+
+### Does ZenUML support AI diagram generation?
+
+ZenUML does not include a built-in AI generation feature inside the Confluence app at this time. However, because ZenUML diagrams are text-based, you can use any AI assistant (ChatGPT, Claude, Gemini, etc.) to generate ZenUML DSL or Mermaid syntax, then paste the result directly into the ZenUML editor.
+
+The [ZenUML MCP server](https://github.com/ZenUml/diagramly-mcp-serverless) (available separately) also enables AI assistants that support the Model Context Protocol to generate and render ZenUML diagrams programmatically as part of an agentic workflow.
+
+### Can multiple users edit the same diagram simultaneously?
+
+ZenUML does not support real-time collaborative co-editing (multiple cursors in the same diagram at once). Confluence's own page locking applies: only one user should have the page in edit mode at a time to avoid conflicts.
+
+For teams with frequent diagram updates, the recommended practice is to treat diagram source the same as code: make changes in short, focused sessions and publish promptly. The text-based nature of ZenUML, Mermaid, and PlantUML diagrams makes merge conflicts easier to resolve than binary diagram formats.
+
+## Technical & Privacy
+
+### Is my diagram content sent to ZenUML servers?
+
+Your diagram text and rendered output is **stored as Confluence custom content on Atlassian's infrastructure** — the same servers that store your page content. ZenUML's own Cloudflare backend handles only app lifecycle events (install/upgrade), licence status checks, and anonymous usage telemetry. Your diagram source is not sent to ZenUML servers for rendering or persistent storage.
+
+**PlantUML is the one exception:** PlantUML diagrams are sent to a PlantUML rendering server (plantuml.com by default) to produce the image. This is consistent with how PlantUML works across all Confluence integrations and is inherent to the PlantUML architecture. If your organisation requires all data to stay within a specific region, consider using a self-hosted PlantUML server and contacting us to configure the endpoint.
+
+### Is ZenUML built on Atlassian Forge or Connect?
+
+ZenUML for Confluence is a **fully Forge-native app**. It uses Atlassian Forge Custom UI and Forge remotes — there is no legacy Atlassian Connect runtime in the production app.
+
+Forge apps run in Atlassian's managed, isolated infrastructure. This means stronger security boundaries, no external webhook server required for JWT authentication, automatic security updates from Atlassian, and alignment with Atlassian's long-term platform direction (Connect is in maintenance mode; Forge is the strategic platform).
+
+### What permissions does ZenUML require?
+
+ZenUML requests the minimum Forge scopes needed to function:
+
+- **Read and write Confluence custom content** — to save and load diagram data associated with macros.
+- **Read page and space context** — to know which page the macro is on and to check space-level diagram counts for Lite enforcement.
+- **Read user account information** — to associate diagrams with their author and display creator information.
+
+ZenUML does **not** request admin permissions, does not read or write page body content, and does not access content outside the pages where its macros are placed.
+
+### Does ZenUML work offline?
+
+No. ZenUML for Confluence is a cloud app that requires an internet connection to Confluence Cloud and Atlassian's Forge runtime. There is no offline or local-only mode within Confluence.
+
+If you need offline diagram editing, the **ZenUML standalone web app** at [app.zenuml.com](https://app.zenuml.com) works in modern browsers with limited offline capability via service worker caching, and supports the same ZenUML DSL syntax. The **ZenUML VS Code extension** also provides offline diagram editing and preview inside Visual Studio Code.
+
+## Troubleshooting
+
+### My diagram is not rendering — what should I check?
+
+Work through these checks in order:
+
+- **Syntax errors:** The ZenUML editor highlights syntax problems in the code panel and shows an inline error message below the preview. For Mermaid diagrams, even a single misplaced character can prevent rendering — read the error message carefully, as it usually names the problematic line.
+- **Hard reload:** Press Ctrl+Shift+R (Windows/Linux) or Cmd+Shift+R (macOS) to fully reload the Confluence page and clear cached state.
+- **Browser console:** Open browser developer tools (F12) and check the Console tab for JavaScript errors. Copy any error messages when reporting a bug.
+- **Browser extensions:** Ad-blockers and privacy extensions occasionally block Forge iframe content. Try in an incognito window with extensions disabled to confirm.
+- **Plan check:** All diagram types are available on both Lite and Full — the plan difference is only the space diagram count, not diagram type access.
+
+If none of these resolve the issue, file a bug report on [GitHub](https://github.com/ZenUml/conf-app/issues) with the diagram source and browser console output.
+
+### The export to PDF or Word includes a blank where my diagram should be — why?
+
+This is a **known limitation of Confluence's native PDF and Word export**. Confluence exports page body HTML without executing JavaScript, so Forge Custom UI macros (which render inside JavaScript-driven iframes) appear blank in exported documents.
+
+To include a diagram in an exported document, use one of these workarounds:
+
+- **Export to PNG first:** Use ZenUML's fullscreen viewer Export button to download the diagram as a PNG image, then insert that image into the Confluence page body before running the Confluence export.
+- **DrawIO SVG export:** For DrawIO diagrams, use the DrawIO editor's File → Export as → SVG to get a vector image, then embed it in the page.
+
+This limitation affects all Forge-based Confluence apps, not only ZenUML. It is a Confluence platform constraint, not an app-specific bug.
+
+### I cannot find ZenUML in the Confluence slash menu — what should I do?
+
+Try these steps in order:
+
+- **Confirm installation:** Go to **Settings → Manage apps** and check that ZenUML appears in the list and is enabled.
+- **Search by partial name:** In the slash menu, type /zen or /diagram — partial matches sometimes surface faster than browsing the full list.
+- **Refresh the editor:** Close the Confluence tab and reopen it with a full page reload. Forge app registrations sometimes require a fresh session to appear in the slash menu.
+- **New editor required:** ZenUML requires the **new Confluence editor**. If your space is still using the legacy editor (fabric), ZenUML macros will not appear. Contact your Confluence admin to enable the new editor for your space.
+- **Admin restrictions:** Your Confluence site admin may have restricted which apps or macro types are available in specific spaces or to specific user groups. Check with your admin.
+
+If the app is installed and enabled but still not appearing after a refresh, file a support request on [GitHub](https://github.com/ZenUml/conf-app/issues).
+
+### How do I report a bug or request a feature?
+
+Open a GitHub issue at [github.com/ZenUml/conf-app/issues](https://github.com/ZenUml/conf-app/issues).
+
+**For bugs,** include:
+
+- The diagram type (Sequence, Mermaid, DrawIO, PlantUML, OpenAPI, or Embed)
+- The DSL or source text that triggers the problem
+- Your browser name and version, and your OS
+- Any error messages from the browser console (F12 → Console)
+- Whether the issue reproduces on a freshly created diagram or only on existing ones
+
+**For feature requests,** describe the use case rather than the specific solution — understanding the underlying need helps the team prioritise correctly.
+
+You can also leave a review and feature suggestion via the [Atlassian Marketplace](https://marketplace.atlassian.com) listing. Reviews are read by the ZenUML product team.
+
+## Still have questions?
+
+Install ZenUML Lite for free and explore all diagram types right inside Confluence. No credit card, no time limit.
+
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218971) [Open a GitHub Issue](https://github.com/ZenUml/conf-app/issues)

--- a/src/pages/confluence/faq.md
+++ b/src/pages/confluence/faq.md
@@ -19,7 +19,7 @@ unlisted: false
 
 Everything you need to know about installing, using, and getting the most out of ZenUML for Confluence.
 
-[Getting Started](#getting-started) [Diagram Types](#diagram-types) [Pricing & Plans](#pricing) [Features & Usage](#features) [Technical & Privacy](#technical) [Troubleshooting](#troubleshooting)
+[Getting Started](#getting-started) · [Diagram Types](#diagram-types) · [Pricing & Plans](#pricing) · [Features & Usage](#features) · [Technical & Privacy](#technical) · [Troubleshooting](#troubleshooting)
 
 ## Getting Started
 
@@ -284,4 +284,4 @@ You can also leave a review and feature suggestion via the [Atlassian Marketplac
 
 Install ZenUML Lite for free and explore all diagram types right inside Confluence. No credit card, no time limit.
 
-[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218971) [Open a GitHub Issue](https://github.com/ZenUml/conf-app/issues)
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218971) · [Open a GitHub Issue](https://github.com/ZenUml/conf-app/issues)

--- a/src/pages/confluence/features.md
+++ b/src/pages/confluence/features.md
@@ -1,0 +1,150 @@
+---
+title: Features — diagramming for Confluence Cloud
+description: 'Six diagram types, an inline editor with live preview, fullscreen viewing, PNG and SVG export, and Forge-native privacy. Every ZenUML for Confluence feature.'
+keywords:
+  [
+    confluence diagram features,
+    confluence diagram editor,
+    confluence diagram export,
+    forge diagram app,
+    inline diagram editor confluence,
+    zenuml features,
+  ]
+unlisted: false
+---
+
+1. [Home](/confluence/)
+2. ›
+3. Features
+
+All Features
+
+# Everything You Need to Diagram in Confluence
+
+ZenUML for Confluence brings a complete diagramming workspace directly into your Atlassian pages — no external tools, no copy-paste friction, no content leaving your Confluence instance. Six diagram types, a distraction-free fullscreen editor, live preview, one-click export, and AI-assisted generation are all included.
+
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [Browse Diagram Types](/confluence/diagram-types/)
+
+Editing Experience
+
+## A workspace built for flow
+
+### Fullscreen Editor
+
+Opens a full-viewport modal editor for any diagram type — ZenUML, Mermaid, PlantUML, DrawIO, OpenAPI, or Embed. Hides all Confluence chrome so you can focus entirely on the diagram.
+
+### Live Preview
+
+The diagram renders in real time as you type — no save required. Syntax errors are highlighted inline so you catch mistakes before they reach your page.
+
+### Diagram as Code
+
+All diagram types except DrawIO are stored as plain text source code in Confluence custom content. Copy the source into Git, review diagram changes in PRs, and diff versions over time — the same workflow your engineers already use for code.
+
+Export & Sharing
+
+## Get diagrams out of Confluence
+
+### Export to PNG & PDF
+
+Export any rendered diagram to PNG or PDF directly from Confluence — from both view mode and edit mode. No third-party tools, no screen captures. PNG is available on all variants; PDF is available on the Full variant.
+
+### Copy Diagram Code
+
+Copy the full diagram source code to the clipboard with a single click. Paste it into another page, a code editor, or a Git repository without opening the editor.
+
+### Version History
+
+Browse the full edit history of any diagram, preview any past version, and restore a previous state with one click. Version history is stored as Confluence custom content versions — no external database required.
+
+Diagram Intelligence
+
+## Smarter diagramming, on your terms
+
+### AI-Assisted Generation
+
+Describe what you want to diagram in plain English, or paste existing page content, and Diagramly AI generates a diagram draft. Available in the Lite variant via the Diagramly AI integration. You remain in full control — the draft is editable before any save.
+
+### Privacy-First Rendering
+
+ZenUML sequence, Mermaid, PlantUML, OpenAPI, and Embed diagrams render entirely in the browser. Diagram source code never leaves your Confluence instance during rendering — not to ZenUML servers, not to third parties.
+
+### Atlassian Forge
+
+Built entirely on modern Atlassian Forge — not the legacy Connect framework. Forge runs in a sandboxed V8 isolate with no persistent server or auth-token storage on ZenUML infrastructure. Permissions are declared in the app manifest and reviewed by Atlassian at install time.
+
+Advanced Diagram Types
+
+## Beyond sequence diagrams
+
+### DrawIO Integration
+
+The full DrawIO drag-and-drop editor is embedded directly in Confluence. Create and edit flowcharts, network diagrams, org charts, and any other graph — no separate DrawIO account or app needed. Diagrams are stored as Confluence custom content.
+
+### OpenAPI Viewer
+
+Paste an OpenAPI 3.x or Swagger 2.x specification into the macro and it renders as an interactive Swagger UI — try endpoints, view schemas, explore authentication requirements — all from within your Confluence page.
+
+### Embed Diagrams
+
+Embed an existing ZenUML, Mermaid, DrawIO, or OpenAPI macro from any Confluence page into another page. Changes to the source diagram propagate automatically — one source of truth, many viewers.
+
+[See all 6 diagram types in detail →](/confluence/diagram-types/)
+
+Compare Plans
+
+## ZenUML Lite vs Full
+
+The Lite variant is free forever. The Full variant adds PDF export, premium support, and priority access to new features.
+
+| Feature | Lite — Free | Full — Paid |
+|---|---|---|
+| **Fullscreen Editor** | ✓ | ✓ |
+| **Live Preview** | ✓ | ✓ |
+| **Diagram as Code** | ✓ | ✓ |
+| **Version History** | ✓ | ✓ |
+| **Export to PNG** | ✓ | ✓ |
+| **Copy Diagram Code** | ✓ | ✓ |
+| **Privacy-First Rendering** | ✓ | ✓ |
+| **Atlassian Forge (modern runtime)** | ✓ | ✓ |
+| **All 6 Diagram Types** | ✓ | ✓ |
+| **DrawIO Integration** | ✓ | ✓ |
+| **OpenAPI Viewer** | ✓ | ✓ |
+| **Embed Diagrams** | ✓ | ✓ |
+| **AI-Assisted Generation** | ✓ | ✓ |
+| **Export to PDF** Full only | ✗ | ✓ |
+| **Priority Support** Full only | ✗ | ✓ |
+
+[See full pricing details →](/confluence/pricing/)
+
+FAQ
+
+## Frequently asked questions
+
+### Does ZenUML for Confluence work with both Lite and Full variants?
+
+Most features are available in both variants. The Lite variant (free) includes live preview, fullscreen editor, version history, PNG export, and all 6 diagram types. AI-assisted generation and PDF export are available in the Full (paid) variant. See the comparison table above for a complete breakdown.
+
+### Is my diagram content sent to ZenUML servers during rendering?
+
+No. All diagram rendering — ZenUML sequence, Mermaid, PlantUML, OpenAPI, and Embed types — happens entirely in the browser. Your diagram source code never leaves your Confluence instance during the rendering process. Only DrawIO syncs canvas state to Cloudflare-backed storage as part of its own integration.
+
+### Can I export diagrams to PNG or PDF?
+
+Yes. PNG export is available in all variants from both view mode and edit mode. PDF export is available in the Full variant. Both formats are generated client-side from the rendered diagram — no server round-trip required.
+
+### How does the AI diagram generation feature work?
+
+The AI generation feature, available in the Lite variant via Diagramly AI, lets you describe a diagram in plain text or paste page content, and it produces a diagram code draft. You can then edit and refine the generated code in the live editor before saving. The AI call goes to Diagramly AI endpoints — review the privacy policy for data handling details.
+
+### What does "Diagram as Code" mean for my team?
+
+All diagram types except DrawIO store diagrams as plain text source code in Confluence custom content. This means you can copy the source, store it in a Git repository, review changes in pull requests, and diff diagram versions over time — the same workflow your engineers already use for code. DrawIO stores an XML-based format that is also human-readable.
+
+Get started for free
+
+## Start diagramming for free
+
+Install ZenUML for Confluence from the Atlassian Marketplace — no credit card required. The Lite variant is free for any team size with no macro limit on publish.
+
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [View Pricing](/confluence/pricing/)

--- a/src/pages/confluence/features.md
+++ b/src/pages/confluence/features.md
@@ -23,7 +23,7 @@ All Features
 
 ZenUML for Confluence brings a complete diagramming workspace directly into your Atlassian pages — no external tools, no copy-paste friction, no content leaving your Confluence instance. Six diagram types, a distraction-free fullscreen editor, live preview, one-click export, and AI-assisted generation are all included.
 
-[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [Browse Diagram Types](/confluence/diagram-types/)
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) · [Browse Diagram Types](/confluence/diagram-types/)
 
 Editing Experience
 
@@ -147,4 +147,4 @@ Get started for free
 
 Install ZenUML for Confluence from the Atlassian Marketplace — no credit card required. The Lite variant is free for any team size with no macro limit on publish.
 
-[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) [View Pricing](/confluence/pricing/)
+[Install Free on Marketplace](https://marketplace.atlassian.com/apps/1218014/zenuml-sequence-diagram) · [View Pricing](/confluence/pricing/)

--- a/src/pages/confluence/index.md
+++ b/src/pages/confluence/index.md
@@ -1,0 +1,194 @@
+---
+title: Diagrams for Confluence Cloud — 6 types, one app
+description: 'An Atlassian Forge app that creates sequence diagrams, Mermaid charts, DrawIO flowcharts, PlantUML and OpenAPI specs inside Confluence Cloud. Free Lite plan.'
+keywords:
+  [
+    zenuml for confluence,
+    confluence diagram app,
+    sequence diagram confluence,
+    mermaid for confluence,
+    drawio confluence,
+    confluence diagramming tool,
+  ]
+unlisted: false
+---
+
+⭐ 4.8 on Atlassian Marketplace  ·  1,000+ installs  ·  Used by enterprise teams
+
+# Diagrams that live inside your Confluence pages
+
+ZenUML for Confluence is an Atlassian Forge app that lets teams create, edit, and maintain sequence diagrams, Mermaid charts, DrawIO flowcharts, PlantUML diagrams, and OpenAPI specs directly on Confluence Cloud pages — no external tools, no copy-pasting images.
+
+[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [See All Features](/confluence/features/)
+
+✓ Free Lite plan — no credit card ✓ Installs in under 2 minutes ✓ Diagrams render in-browser — private by design ✓ Used by teams at Amazon & ThoughtWorks
+
+## What is ZenUML for Confluence?
+
+ZenUML for Confluence is an add-on for **Atlassian Confluence Cloud** that embeds a full-featured diagramming environment directly into the Confluence page editor. Rather than exporting a diagram as an image from an external tool and uploading it, teams write or draw diagrams inside a Confluence macro. The source code is stored in Confluence custom content, and the diagram is re-rendered in the browser on every page view — keeping diagrams and documentation in sync.
+
+The app supports **six diagram types** in a single installation: ZenUML sequence diagrams (standards-compliant with OMG UML 2.5.1), Mermaid charts, PlantUML diagrams, DrawIO flowcharts, OpenAPI/Swagger specification rendering, and an embed type for reusing existing diagrams. Engineering teams, solution architects, and technical writers use it to keep architecture documentation, API specs, and process flows up to date alongside their Confluence pages.
+
+ZenUML for Confluence is published on the Atlassian Marketplace by **P&D VISION** and is available in two variants. The **Lite** plan is free and supports up to 100 diagrams per Confluence space — it has been installed by more than 898 teams and is rated 4.5 stars. The **Full** plan removes the per-space limit and is rated 4.8 stars. Both variants are native Atlassian Forge apps: they run on Atlassian infrastructure and never transmit diagram content to external servers.
+
+## 6 Diagram Types, One App
+
+Install once. Every diagram type your engineering team needs is available from the same Confluence macro.
+
+### ZenUML Sequence
+
+Write UML 2.5.1-compliant sequence diagrams in ZenUML DSL — a concise, readable text syntax. Live preview, syntax highlighting, and AI-assisted generation included. Ideal for API flows, service interactions, and system design docs.
+
+### Mermaid
+
+Full Mermaid.js support — flowcharts, sequence diagrams, Gantt charts, ER diagrams, class diagrams, state diagrams, and pie charts. Write Mermaid directly in Confluence without any external tool.
+
+### PlantUML
+
+Render PlantUML class diagrams, component diagrams, activity diagrams, use-case diagrams, and deployment diagrams. Paste your existing PlantUML code directly into the editor.
+
+### DrawIO / Graph
+
+Drag-and-drop flowcharts, network diagrams, org charts, and general-purpose graphs using the DrawIO engine — fully embedded in Confluence. No DrawIO account required.
+
+### OpenAPI / Swagger
+
+Paste an OpenAPI 3.x or Swagger 2.0 spec in YAML or JSON and get an interactive swagger-ui rendered on the Confluence page — complete with endpoint explorer and request/response schemas.
+
+### Embed
+
+Reuse an existing ZenUML sequence diagram, DrawIO graph, or OpenAPI spec from another Confluence page or space. Keep a single source of truth and let all referencing pages stay in sync automatically.
+
+[Explore all diagram types](/confluence/diagram-types/)
+
+## Built for engineering teams
+
+Everything you need to create, maintain, and share technical diagrams — without leaving Confluence.
+
+### Fullscreen Editor
+
+A distraction-free fullscreen editing modal with split-pane layout: code on the left, live diagram on the right. Resize panes to suit your workflow.
+
+### Live Preview
+
+See your diagram update in real time as you type. No save-to-preview cycle — the rendered output tracks the editor cursor-by-cursor.
+
+### Export PNG & PDF
+
+Export any diagram to PNG or PDF directly from the viewer. Share diagrams in presentations, design docs, or review threads without re-screenshotting.
+
+### Version History
+
+Every save is a new Confluence custom content version. Browse, restore, and compare previous diagram states through Confluence's built-in version history.
+
+### Copy Code
+
+Copy the diagram source to clipboard with one click. Move diagrams between pages, share in Slack, or check them into a Git repository alongside your code.
+
+### Diagram as Code
+
+Diagrams are stored as plain text — ZenUML DSL, Mermaid, PlantUML, or DrawIO XML. Diffs are readable, merges are possible, and regeneration is instant when your architecture changes.
+
+### AI-Assisted Generation
+
+Describe a flow in natural language and let AI generate the ZenUML or Mermaid source for you. Edit the output directly in the editor — AI is a starting point, not a black box.
+
+### Privacy-First
+
+All rendering happens in the browser. Diagram content — including confidential architecture diagrams and API specs — is never sent to ZenUML servers. Suitable for teams with strict data residency requirements.
+
+[See full feature list](/confluence/features/)
+
+## Free vs Paid
+
+Start free. Upgrade when your team grows. Both variants include all six diagram types.
+
+| Feature | Lite Free | Full Paid |
+|---|---|---|
+| All 6 diagram types | ✓ | ✓ |
+| Fullscreen editor + live preview | ✓ | ✓ |
+| Export PNG & PDF | ✓ | ✓ |
+| Version history | ✓ | ✓ |
+| AI-assisted diagram generation | ✓ | ✓ |
+| Privacy-first in-browser rendering | ✓ | ✓ |
+| Diagrams per Confluence space | Up to 100 | Unlimited |
+| Atlassian Marketplace rating | ⭐ 4.5 | ⭐ 4.8 |
+| Installs | 898+ | — |
+| Price | Free | Marketplace subscription |
+
+[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [Full pricing details](/confluence/pricing/)
+
+## Frequently Asked Questions
+
+Common questions about ZenUML for Confluence — diagram types, privacy, pricing, and getting started.
+
+### What diagram types does ZenUML for Confluence support?
+
+- **ZenUML Sequence** — text-based UML 2.5.1 sequence diagrams using ZenUML DSL
+- **Mermaid** — full Mermaid.js syntax (flowcharts, Gantt, ER, class, state, pie, and more)
+- **PlantUML** — class, activity, component, use-case, and deployment diagrams
+- **DrawIO / Graph** — drag-and-drop flowcharts and graphs using the DrawIO engine
+- **OpenAPI / Swagger** — interactive rendering of OpenAPI 3.x and Swagger 2.0 specs
+- **Embed** — reuse a diagram from another page or space as a live reference
+
+### Is ZenUML for Confluence free?
+
+Yes — **ZenUML Lite is completely free**, no credit card required. The free Lite plan supports all six diagram types and allows up to 100 diagrams per Confluence space. It has been installed by more than 898 teams and carries a 4.5-star rating on the Atlassian Marketplace. For teams that need unlimited diagrams across all spaces, the paid **Full version** is available via the Atlassian Marketplace on a per-user subscription basis and is rated 4.8 stars.
+
+### How does ZenUML compare to Gliffy and Lucidchart?
+
+- **Diagram as code** — ZenUML stores diagrams as plain text (ZenUML DSL, Mermaid, PlantUML), making them versionable and diffable
+- **Multi-syntax** — one app covers ZenUML, Mermaid, PlantUML, DrawIO, and OpenAPI; Gliffy/Lucidchart are format-specific
+- **Privacy-first** — all rendering is in-browser; diagram content never reaches ZenUML servers
+- **Genuinely free tier** — Lite is free, not a timed trial
+
+### Can I use Mermaid syntax in Confluence with ZenUML?
+
+Yes. ZenUML for Confluence includes a full **Mermaid.js renderer**. You can write any valid Mermaid diagram — flowcharts, sequence diagrams, Gantt charts, ER diagrams, class diagrams, state diagrams, pie charts, and more — directly in the ZenUML macro editor. The live preview updates as you type. Diagrams are stored as Mermaid source text in Confluence custom content and rendered in the browser on every page view. No external Mermaid account or service is required.
+
+### Does ZenUML support DrawIO diagrams in Confluence?
+
+Yes. ZenUML for Confluence includes the **DrawIO engine** for creating flowcharts, network diagrams, org charts, and general-purpose graphs. The DrawIO editor opens in a fullscreen modal inside Confluence, providing the full DrawIO canvas — shapes, connectors, layers, and export. Diagrams are stored in Confluence custom content and rendered inline on the page. No separate DrawIO account or subscription is required.
+
+### Is my diagram content sent to external servers?
+
+**No.** ZenUML for Confluence is privacy-first by design. All diagram rendering — ZenUML sequence diagrams, Mermaid charts, PlantUML diagrams, DrawIO graphs, and OpenAPI specs — happens entirely in the **browser using client-side engines**. Your diagram source code and rendered output are never transmitted to ZenUML servers. Diagrams are stored as Confluence custom content within your Atlassian instance. This design makes ZenUML suitable for teams with strict data residency or confidentiality requirements.
+
+### What is the difference between the Lite and Full versions?
+
+- **Lite (free)** — up to 100 diagrams per Confluence space. Rated 4.5★, 898+ installs.
+- **Full (paid)** — unlimited diagrams across all spaces. Rated 4.8★. Billed per user via Atlassian Marketplace.
+
+### How do I install ZenUML in Confluence?
+
+1. Go to the [Atlassian Marketplace](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) and search for "ZenUML".
+2. Choose the **Lite** (free) or **Full** (paid) listing and click **"Get it now"**.
+3. Select your Confluence Cloud site and confirm the installation.
+
+[View full FAQ →](/confluence/faq/)
+
+## Install in Minutes
+
+ZenUML is a native Atlassian Forge app — no servers to configure, no external accounts to create.
+
+1
+
+### Find on Marketplace
+
+Go to the Atlassian Marketplace and search for **"ZenUML"**. Choose Lite (free) or Full (paid) based on your team's needs.
+
+2
+
+### Click "Get it now"
+
+Select your Confluence Cloud site and confirm. Atlassian handles the install — no download, no ZIP file, no server configuration. Admin permission required.
+
+3
+
+### Insert a macro and diagram
+
+On any Confluence page, type `/ZenUML` or use the macro picker to insert a diagram. Choose your type, write or paste your code, and click Publish.
+
+[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+
+Used by engineering teams at Amazon, ThoughtWorks, and more.  |  Published by **P&D VISION** on Atlassian Marketplace.

--- a/src/pages/confluence/index.md
+++ b/src/pages/confluence/index.md
@@ -19,7 +19,7 @@ unlisted: false
 
 ZenUML for Confluence is an Atlassian Forge app that lets teams create, edit, and maintain sequence diagrams, Mermaid charts, DrawIO flowcharts, PlantUML diagrams, and OpenAPI specs directly on Confluence Cloud pages — no external tools, no copy-pasting images.
 
-[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [See All Features](/confluence/features/)
+[⚡ Install Free — Lite Plan](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [See All Features](/confluence/features/)
 
 ✓ Free Lite plan — no credit card ✓ Installs in under 2 minutes ✓ Diagrams render in-browser — private by design ✓ Used by teams at Amazon & ThoughtWorks
 
@@ -116,7 +116,7 @@ Start free. Upgrade when your team grows. Both variants include all six diagram 
 | Installs | 898+ | — |
 | Price | Free | Marketplace subscription |
 
-[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) [Full pricing details](/confluence/pricing/)
+[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence) · [Full pricing details](/confluence/pricing/)
 
 ## Frequently Asked Questions
 
@@ -189,6 +189,6 @@ Select your Confluence Cloud site and confirm. Atlassian handles the install —
 
 On any Confluence page, type `/ZenUML` or use the macro picker to insert a diagram. Choose your type, write or paste your code, and click Publish.
 
-[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+[⚡ Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [Install Full — Paid](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
 
 Used by engineering teams at Amazon, ThoughtWorks, and more.  |  Published by **P&D VISION** on Atlassian Marketplace.

--- a/src/pages/confluence/install.md
+++ b/src/pages/confluence/install.md
@@ -21,7 +21,7 @@ Install directly from the Atlassian Marketplace — no dev setup, no credit card
 
 Atlassian Marketplace verified Forge-native — no external servers required Free Lite plan, no credit card needed Confluence Cloud only
 
-[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [View Full Plan](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [View Full Plan](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
 
 ## Six steps from zero to your first diagram
 
@@ -167,6 +167,6 @@ Yes. Upgrading from Lite to Full is a plan change within the same Atlassian Mark
 
 Install ZenUML Lite for free in under 2 minutes — no credit card, no expiry. Upgrade to Full any time.
 
-[Install Lite Free on Marketplace](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [View Full Plan](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+[Install Lite Free on Marketplace](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) · [View Full Plan](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
 
 Questions? Visit our [FAQ](/confluence/faq/) or [contact support](mailto:support@zenuml.com).

--- a/src/pages/confluence/install.md
+++ b/src/pages/confluence/install.md
@@ -1,0 +1,172 @@
+---
+title: Install ZenUML for Confluence — free in 2 minutes
+description: 'Install ZenUML for Confluence from the Atlassian Marketplace and insert your first diagram macro. No credit card, no external service, under two minutes.'
+keywords:
+  [
+    install zenuml confluence,
+    confluence diagram plugin install,
+    atlassian marketplace zenuml,
+    add diagram macro confluence,
+    confluence forge app install,
+    zenuml setup,
+  ]
+unlisted: false
+---
+
+[Home](/confluence/) › Install
+
+# Get ZenUML in Your Confluence in 2 Minutes
+
+Install directly from the Atlassian Marketplace — no dev setup, no credit card. The Lite plan is free forever.
+
+Atlassian Marketplace verified Forge-native — no external servers required Free Lite plan, no credit card needed Confluence Cloud only
+
+[Install Lite — Free](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [View Full Plan](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+
+## Six steps from zero to your first diagram
+
+No developer skills required. If you can edit a Confluence page, you can create a diagram.
+
+1
+
+### Go to the Atlassian Marketplace
+
+Open [marketplace.atlassian.com](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) and search for **ZenUML**. You can search directly for "ZenUML Lite" (free) or "ZenUML for Confluence" (Full paid plan). The listing is published by *ZenUML* and shows the Atlassian verified badge.
+
+2
+
+### Choose Lite (free) or Full (paid)
+
+**Lite** is free forever — all six diagram types, up to 100 macros per space, no time limit. **Full** removes the per-space macro limit, adds priority support, and unlocks advanced PDF export and custom branding options.
+
+3
+
+### Click "Try it free" / "Get app" and approve Forge permissions
+
+Atlassian will display the Forge permission scopes the app requests before you confirm installation. ZenUML requests:
+
+- **Read** Confluence content (pages, spaces) — to display diagrams stored as custom content
+- **Write** Confluence content — to save and update diagram data when you publish
+
+No scopes outside Confluence content are requested. Your diagram data is stored as Confluence custom content — it lives inside your Confluence site, not on a third-party server.
+
+4
+
+### Open a Confluence page in edit mode and type /diagram
+
+Navigate to any Confluence page, click **Edit** to enter edit mode, then click in the page body and type /diagram. The ZenUML — Diagram as Code macro will appear in the insert menu. Click it to open the diagram editor.
+
+5
+
+### Choose your diagram type
+
+The editor opens a type picker. Six options are available:
+
+- **Sequence** — ZenUML DSL for sequence / interaction diagrams
+- **Mermaid** — flowcharts, ER diagrams, Gantt charts, and more
+- **DrawIO** — full visual graph editor (drag-and-drop)
+- **PlantUML** — class, component, state, and activity diagrams
+- **OpenAPI** — render any OpenAPI/Swagger spec as interactive docs
+- **Embed** — embed an existing ZenUML, DrawIO, or API diagram
+
+6
+
+### Write or generate your diagram and click Publish
+
+Type your diagram code (or use a template) in the left-hand editor panel. The diagram renders live on the right. When you are happy with the result, click **Publish**. The diagram is saved to your Confluence page as custom content and is visible to anyone with page-view permissions.
+
+[Install Lite Free — Start Now](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence)
+
+## What permissions does ZenUML need?
+
+ZenUML is a Forge-native app. Atlassian's Forge platform enforces permission scopes at the platform level — the app can only do what the scopes allow.
+
+ZenUML reads page context so it can load diagram data stored as custom content on that page. It never reads or indexes content outside pages where a ZenUML macro is present.
+
+When you click Publish, ZenUML saves your diagram code as Confluence custom content (a first-class Confluence data type). This is the only write operation — it does not modify page text, titles, or any other page content.
+
+Diagram source code and rendered output stay inside your Confluence site. ZenUML uses a Cloudflare Workers backend only for license checks and optional telemetry — your diagram content is never sent there.
+
+ZenUML does not request access to Jira, Bitbucket, user profiles, email addresses, or any Atlassian product outside the Confluence content API.
+
+## Start with Lite, upgrade when ready
+
+Every ZenUML feature is available on both plans. The difference is scale and support.
+
+Free forever
+
+Lite
+
+$0 / month
+
+No credit card. No expiry.
+
+- All 6 diagram types
+- Up to 100 macros per space
+- Full diagram editor (code + visual)
+- Confluence Cloud only
+- Community support
+
+Paid plan
+
+Full
+
+Marketplace pricing
+
+Per-user Atlassian billing. 30-day free trial.
+
+- Everything in Lite
+- Unlimited macros per space
+- Advanced PDF export
+- Priority email support
+- SLA for enterprise customers
+
+Upgrading from Lite to Full preserves all your existing diagrams — no migration needed.
+
+## Who installs ZenUML?
+
+Installation scope depends on your Confluence role. Both paths are fully supported.
+
+### 🏢 Confluence Site Admin
+
+A site admin (Confluence administrator) can install ZenUML for the **entire Confluence site**. Once installed at site level, the /diagram macro is available in every space immediately — no per-space action needed.
+
+Install path: Confluence Settings → Manage apps → Find new apps → search ZenUML.
+
+### 📁 Space Admin
+
+A space admin can install Marketplace apps scoped to their own space if the Confluence site allows user-installed apps. This gives teams autonomy to add ZenUML without waiting for a global admin.
+
+Install path: Space Settings → Apps → Find apps → search ZenUML. (Option visibility depends on site-level permissions set by the site admin.)
+
+**Not an admin?** Share this page with your Confluence site admin and ask them to install ZenUML Lite — it takes under 2 minutes and is completely free. Once installed, every editor on the site can insert diagrams immediately.
+
+## Installation questions
+
+### Does ZenUML work on Confluence Server or Data Center?
+
+ZenUML for Confluence is a **Confluence Cloud-only** app built on Atlassian's Forge platform. It is not compatible with Confluence Server or Confluence Data Center. If you are on Server or Data Center, the app will not appear as an installable option in your Marketplace.
+
+### Do I need a credit card to install the Lite plan?
+
+No. The Lite plan is free with no trial period and no credit card required. Atlassian handles billing for all Marketplace apps — you will only be asked for payment details if you choose to upgrade to the Full paid plan, which starts a 30-day free trial.
+
+### How do I verify the installation was successful?
+
+After installation, navigate to any Confluence page and enter edit mode. Type `/diagram` in the page body. If the ZenUML macro appears in the suggestion list, the installation is working. You can also confirm under *Confluence Settings → Manage apps* — ZenUML should appear as "Enabled".
+
+### What happens to my diagrams if I uninstall ZenUML?
+
+Your diagram source code is stored as Confluence custom content, which is part of your Confluence data. If you uninstall ZenUML, the macro placeholders remain on your pages but will no longer render. If you reinstall ZenUML, all diagrams will render again from the stored custom content — nothing is lost. Atlassian's data retention policy applies to all custom content on your site.
+
+### Can I switch from the Lite plan to the Full plan without losing diagrams?
+
+Yes. Upgrading from Lite to Full is a plan change within the same Atlassian Marketplace app — it does not require uninstalling and reinstalling. All your existing diagrams are preserved exactly as they are. The upgrade takes effect immediately after you confirm billing in the Atlassian admin panel.
+
+## Ready to install?
+
+Install ZenUML Lite for free in under 2 minutes — no credit card, no expiry. Upgrade to Full any time.
+
+[Install Lite Free on Marketplace](https://marketplace.atlassian.com/search?query=zenuml+lite&hosting=cloud&product=confluence) [View Full Plan](https://marketplace.atlassian.com/search?query=zenuml+confluence&hosting=cloud&product=confluence)
+
+Questions? Visit our [FAQ](/confluence/faq/) or [contact support](mailto:support@zenuml.com).

--- a/src/pages/confluence/pricing.md
+++ b/src/pages/confluence/pricing.md
@@ -19,11 +19,9 @@ Atlassian Marketplace App
 
 Free to start — no credit card required. The Lite plan is permanently free for up to 100 diagrams per space. Upgrade when you need more.
 
-[Install Lite Free](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram) [View Full Plan on Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)
+[Install Lite Free](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram) · [View Full Plan on Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)
 
-Lite
-
-Free
+## Lite — free
 
 Forever free · No credit card
 
@@ -36,9 +34,7 @@ Forever free · No credit card
 - Embed existing diagrams across pages
 - Available on Atlassian Marketplace at no cost
 
-Full
-
-Paid
+## Full — paid
 
 Per-user pricing · [See current price on Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)
 
@@ -124,4 +120,4 @@ Have another question? [Visit the full FAQ](/confluence/faq/) or [view support r
 
 Lite is free, forever. No credit card. No setup fees. Install directly from the Atlassian Marketplace in under a minute.
 
-[Install Lite Free — Atlassian Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram) [View Full Plan Pricing](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)
+[Install Lite Free — Atlassian Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram) · [View Full Plan Pricing](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)

--- a/src/pages/confluence/pricing.md
+++ b/src/pages/confluence/pricing.md
@@ -1,0 +1,127 @@
+---
+title: Pricing — free Lite plan and paid Full plan
+description: 'ZenUML for Confluence is free to start. Lite supports up to 100 diagrams per Confluence space at no cost. Full removes the per-space limit.'
+keywords:
+  [
+    zenuml pricing,
+    confluence diagram app pricing,
+    free confluence diagram plugin,
+    confluence diagram plugin cost,
+    zenuml lite free,
+    zenuml full plan,
+  ]
+unlisted: false
+---
+
+Atlassian Marketplace App
+
+# Simple, Transparent Pricing
+
+Free to start — no credit card required. The Lite plan is permanently free for up to 100 diagrams per space. Upgrade when you need more.
+
+[Install Lite Free](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram) [View Full Plan on Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)
+
+Lite
+
+Free
+
+Forever free · No credit card
+
+- Up to 100 diagrams per Confluence space
+- All 6 diagram types (Sequence, Mermaid, PlantUML, Graph, OpenAPI, Embed)
+- Full editor with syntax highlighting
+- View diagrams in Confluence pages
+- Fullscreen viewer
+- Export diagrams as PNG/SVG
+- Embed existing diagrams across pages
+- Available on Atlassian Marketplace at no cost
+
+Full
+
+Paid
+
+Per-user pricing · [See current price on Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)
+
+- **Unlimited diagrams** per space
+- Everything in Lite
+- No per-space diagram limit
+- Priority support
+- Billed and managed via Atlassian Marketplace
+- Free evaluation period (see Marketplace)
+
+## Full Feature Comparison
+
+| Feature | Lite (Free) | Full (Paid) |
+|---|---|---|
+| **Diagram Limits** |  |  |
+| Diagrams per Confluence space | Up to 100 | Unlimited |
+| Diagram types available | All 6 | All 6 |
+| **Diagram Types** |  |  |
+| Sequence diagrams (ZenUML) | ✓ | ✓ |
+| Mermaid diagrams | ✓ | ✓ |
+| PlantUML diagrams | ✓ | ✓ |
+| Graph diagrams (DrawIO-powered) | ✓ | ✓ |
+| OpenAPI / Swagger specifications | ✓ | ✓ |
+| Embed existing diagrams | ✓ | ✓ |
+| **Editing & Viewing** |  |  |
+| Inline editor with syntax highlighting | ✓ | ✓ |
+| Live diagram preview while editing | ✓ | ✓ |
+| View diagrams in Confluence pages | ✓ | ✓ |
+| Fullscreen viewer | ✓ | ✓ |
+| Export as PNG / SVG | ✓ | ✓ |
+| **Platform & Billing** |  |  |
+| Available on Atlassian Marketplace | ✓ | ✓ |
+| Credit card required | ✗ No | Via Atlassian |
+| Billing managed by Atlassian | N/A (free) | ✓ |
+| Free evaluation period | Permanently free | See Marketplace |
+| Priority support | ✗ | ✓ |
+
+## What counts as a diagram?
+
+The short answer: each macro instance on a Confluence page is one diagram.
+
+### One macro instance = one diagram
+
+Every time you insert a ZenUML macro onto a Confluence page, that insertion is counted as one diagram within the space it lives in. The count is per-space, not per-page or per-user.
+
+For example, if you insert three ZenUML macros onto a single Confluence page, that page contributes three diagrams to your space's count.
+
+The **Embed** diagram type (which re-uses an existing diagram) counts as one diagram for the embed macro itself — the original source diagram also has its own count.
+
+Viewing a diagram — even thousands of times — does not affect your count. Only saved macro instances matter.
+
+**Lite limit: 100 diagrams per space.** Once a space reaches 100, new diagrams cannot be added to that space until you upgrade to Full or remove existing diagrams. Other spaces are unaffected — each space has its own independent count.
+
+## Pricing FAQ
+
+### Is ZenUML for Confluence really free?
+
+Yes. The Lite plan is free on the Atlassian Marketplace — no credit card, no trial period, no expiry. You can install it today and start creating diagrams at no cost. Lite supports up to 100 diagrams per Confluence space, with all 6 diagram types included.
+
+### What happens when I reach 100 diagrams in a space?
+
+When a space reaches 100 diagrams on the Lite plan, a paywall prompt appears when you try to create or edit diagrams in that space. Existing diagrams remain fully visible to all readers — nothing breaks or disappears. You have two options: upgrade to the Full plan for unlimited diagrams, or remove existing diagrams from the space to stay within the limit. Other spaces on your Confluence instance are not affected.
+
+### How is billing handled?
+
+Billing is handled entirely by Atlassian Marketplace. ZenUML never sees or stores your payment details. You manage your subscription, invoices, and seat count through your Atlassian account at [my.atlassian.com](https://my.atlassian.com). This is the same billing system you use for all other Atlassian Marketplace apps.
+
+### Can I try Full before paying?
+
+Atlassian Marketplace offers a free evaluation period for paid apps. Check the [Marketplace listing](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram) for current trial terms. After the evaluation period, billing begins automatically through your Atlassian account. You can cancel at any time.
+
+### Is pricing per user or per space?
+
+Pricing for the Full plan follows Atlassian Marketplace's standard per-user model. The cost is based on the number of users on your Confluence instance — you do not pay separately per space. The Lite plan is free regardless of how many users or spaces you have.
+
+### What happens if I uninstall and reinstall?
+
+Your diagram content is stored as Confluence custom content — it lives in your Confluence instance, not on ZenUML's servers. If you uninstall and reinstall ZenUML for Confluence, all your existing diagrams remain in Confluence and will be accessible again after reinstallation. You will not lose any diagrams by cycling the app.
+
+Have another question? [Visit the full FAQ](/confluence/faq/) or [view support resources on Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram).
+
+## Start diagramming in Confluence today
+
+Lite is free, forever. No credit card. No setup fees. Install directly from the Atlassian Marketplace in under a minute.
+
+[Install Lite Free — Atlassian Marketplace](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram) [View Full Plan Pricing](https://marketplace.atlassian.com/apps/1226524/zenuml-sequence-diagram)


### PR DESCRIPTION
## What

Adds 11 landing pages under `/confluence/`, ported from the standalone marketing site that lives in
`ZenUml/conf-app` at `website/`. That site was committed on 2026-06-07 and never deployed:
`confluence.zenuml.com/` returns 302 to `zenuml.com/`, every sub-path returns 404, and both
`robots.txt` and `sitemap.xml` return 404.

## Why here and not on the subdomain

| | zenuml.com | confluence.zenuml.com |
|---|---|---|
| sitemap URLs | 491 | robots.txt and sitemap.xml both 404 |
| Confluence-topic pages | 19, earliest 2024-02 | 0 |
| root path | 200 | 302 to zenuml.com |

Domain-level signals accumulate per host. A subdirectory reuses what this domain already has; a new
subdomain starts from zero. Both hostnames already resolve to the same Cloudflare zone.

## Changes

- `src/pages/confluence/` — 11 pages, 17,352 words. Frontmatter follows `src/pages/mini-sites.md`.
- `docusaurus.config.ts` — the footer "Diagrams for Confluence" link now points at `/confluence`
  instead of the Marketplace, so every page on the site links into the new hub.
- `docs/products/zenuml-diagrams-for-confluence.md` — keywords narrowed to how-to intent and a link
  added to `/confluence`. The 7 product keywords it carried overlapped the new hub and the two pages
  would have competed for the same queries. The page keeps its docs role and sidebar position.

## Verification

`docusaurus build` succeeds with no MDX errors. Checked against the build output:

- 11 pages built, all 11 in `sitemap.xml` (491 URLs -> 502)
- canonical on each page points at `https://zenuml.com/confluence/...`
- rendered `<title>` is 36-58 chars on every page, including the ` | ZenUML` suffix Docusaurus appends
- meta description 139-157 chars (the standalone homepage shipped 265)
- one `<h1>` per page
- every internal link in the section resolves inside the build

Rendering confirmed in a browser against a local server for `/confluence/` and `/confluence/pricing/`.

## After merge

`confluence.zenuml.com/*` still needs a Cloudflare 301 to `zenuml.com/confluence/*`. It is a 302 today
and its sub-paths 404. That is a separate change on the Cloudflare zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LooeVhpxC5qb8HzW6mvQ3