### PR TITLE
feat(seo): add /privacy /terms /about trust pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -262,13 +262,22 @@ const config: Config = {
               label: 'GitHub',
               href: 'https://github.com/ZenUml',
             },
+          ],
+        },
+        {
+          title: 'Legal',
+          items: [
             {
-              label: 'EULA',
-              href: 'https://app.zenuml.com/End-User-License-Agreement/index.html',
+              label: 'About',
+              to: '/about',
             },
             {
               label: 'Privacy Policy',
-              href: 'https://app.zenuml.com/privacy-policy/privacy-policy.html',
+              to: '/privacy',
+            },
+            {
+              label: 'Terms of Use / EULA',
+              to: '/terms',
             },
           ],
         },

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -1,0 +1,53 @@
+---
+title: About Us
+description: 'ZenUML is a diagram-as-code product family by P&D Vision Pty Ltd (Australia), for Confluence, the web, JetBrains, VS Code, and desktop apps.'
+keywords:
+  [
+    about zenuml,
+    zenuml company,
+    p&d vision pty ltd,
+    diagram as code,
+    zenuml contact,
+  ]
+unlisted: false
+---
+
+# About ZenUML
+
+**ZenUML** is a diagram-as-code product family operated by **P&D Vision Pty Ltd**, an Australian
+company. It renders concise, Markdown-inspired text definitions into sequence diagrams and other
+UML diagrams.
+
+## Where ZenUML runs
+
+ZenUML ships across several platforms so a diagram written once can be used wherever the team
+already works:
+
+- [ZenUML Diagrams for Confluence](/confluence) — Atlassian Marketplace app for Confluence Cloud
+- [ZenUML Online Editor](https://app.zenuml.com/) — a web app
+- [Chrome extension](https://chrome.google.com/webstore/detail/web-sequence/kcpganeflmhffnlofpdmcjklmdpbbmef)
+- [JetBrains plugin](https://plugins.jetbrains.com/plugin/12437-zenuml-support)
+- [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=mrcoder.zenuml)
+- Desktop apps for Mac and Windows
+
+## Origins
+
+ZenUML began as a diagramming tool built inside a finance-industry project, and that background
+shaped an early product decision: rendering had to be trustworthy for regulated environments.
+
+## Privacy by design
+
+Diagrams render **entirely in your browser** — no diagram content is sent to a ZenUML server to be
+drawn, including when exporting an image. See the [Privacy Policy](/privacy) for the full detail on
+what data we do collect (usage analytics, cookies) and how it's used.
+
+## Legal
+
+- [Privacy Policy](/privacy)
+- [Terms of Use / EULA](/terms)
+
+## Contact
+
+Questions, support requests, or feedback — reach us directly:
+
+**Email:** [support@zenuml.com](mailto:support@zenuml.com)

--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -1,0 +1,109 @@
+---
+title: Privacy Policy
+description: 'ZenUML privacy policy: what data we collect across our Confluence, web, IDE, and desktop apps, how it is used, and your rights as a user.'
+keywords:
+  [
+    zenuml privacy policy,
+    zenuml data collection,
+    zenuml gdpr,
+    confluence app privacy,
+    diagram tool privacy,
+  ]
+unlisted: false
+---
+
+# ZenUML Privacy Policy
+
+Effective date: Mar 23, 2023 <br />
+Last updated: Mar 23, 2023
+
+ZenUML ("us", "we", or "our") is operated by P&D Vision Pty Ltd, an Australian company, and provides
+the ZenUML product family — including apps for Atlassian Confluence, the web app at
+[app.zenuml.com](https://app.zenuml.com/), JetBrains and Visual Studio Code plugins, and desktop apps
+(the "Service"). This page informs you of our policies regarding the collection, use, and disclosure of
+personal data when you use our Service and the choices you have associated with that data.
+By using the Service, you agree to the collection and use of information in accordance with this policy.
+
+## Information Collection And Use
+
+We collect several different types of information for various purposes to provide and improve our Service to you.
+
+### Types of Data Collected
+
+#### Usage Data
+
+We may also collect anonymous information (non identifiable) how the Service is accessed and used ("Usage Data"). This Usage Data may include information such as your computer's Internet Protocol address (e.g. IP address), browser type, browser version, the pages of our Service that you visit, the time and date of your visit, the time spent on those pages, unique device identifiers and other diagnostic data.
+
+#### Tracking & Cookies Data
+
+We use cookies and similar tracking technologies to track the activity on our Service and hold certain information.
+Cookies are files with small amount of data which may include an anonymous unique identifier. Cookies are sent to your browser from a website and stored on your device. Tracking technologies also used are beacons, tags, and scripts to collect and track information and to improve and analyze our Service.
+You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent. However, if you do not accept cookies, you may not be able to use some portions of our Service.
+Examples of Cookies we use:
+
+- Session Cookies. We use Session Cookies to operate our Service.
+- Preference Cookies. We use Preference Cookies to remember your preferences and various settings.
+- Security Cookies. We use Security Cookies for security purposes.
+
+## Use of Data
+
+ZenUML uses the collected data for various purposes:
+
+- To provide and maintain the Service
+- To provide customer care and support
+- To provide analysis or valuable information so that we can improve the Service
+- To monitor the usage of the Service
+- To detect, prevent and address technical issues
+
+## Transfer Of Data
+
+Your information, may be transferred to — and maintained on — computers located outside your state, province, country or other governmental jurisdiction where the data protection laws may differ than those from your jurisdiction.
+Your consent to this Privacy Policy followed by your submission of such information represents your agreement to that transfer.
+ZenUML will take all steps reasonably necessary to ensure that your data is treated securely and in accordance with this Privacy Policy.
+
+## Disclosure Of Data
+
+### Legal Requirements
+
+ZenUML may disclose Usage Data in the good faith belief that such action is necessary to:
+
+- To comply with a legal obligation
+- To protect and defend the rights or property of ZenUML
+- To prevent or investigate possible wrongdoing in connection with the Service
+- To protect the personal safety of users of the Service or the public
+- To protect against legal liability
+
+## Security Of Data
+
+The security of your data is important to us, but remember that no method of transmission over the Internet, or method of electronic storage is 100% secure. We strive to use commercially acceptable means to protect your Usage Data. The Service works over encrypted Secure Socket Layer (SSL) technology.
+
+## Service Providers
+
+We may employ third party companies and individuals to facilitate our Service ("Service Providers"), to provide the Service on our behalf, to perform Service-related services or to assist us in analyzing how our Service is used.
+These third parties have access to your Usage Data only to perform these tasks on our behalf and are obligated not to disclose or use it for any other purpose.
+
+### Analytics
+
+We may use third-party Service Providers to monitor and analyze the use of our Service.
+
+- Google Analytics:
+  Google Analytics is a web analytics service offered by Google that tracks and reports anonymous website traffic. Google uses the data collected to track and monitor the use of our Service. This data is shared with other Google services. Google may use the collected data to contextualize and personalize the ads of its own advertising network.
+  You can opt-out of having made your activity on the Service available to Google Analytics by installing the Google Analytics opt-out browser add-on. The add-on prevents the Google Analytics JavaScript (ga.js, analytics.js, and dc.js) from sharing information with Google Analytics about visits activity.
+  For more information on the privacy practices of Google, please visit the Google Privacy & Terms web page: https://policies.google.com/privacy?hl=en
+
+## Links To Other Sites
+
+Our Service may contain links to other sites that are not operated by us. If you click on a third party link, you will be directed to that third party's site. We strongly advise you to review the Privacy Policy of every site you visit.
+We have no control over and assume no responsibility for the content, privacy policies or practices of any third party sites or services.
+
+## Changes To This Privacy Policy
+
+We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.
+We will let you know via email and/or a prominent notice on our Service, prior to the change becoming effective and update the "effective date" at the top of this Privacy Policy.
+You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy, please contact us:
+
+- By email: [support@zenuml.com](mailto:support@zenuml.com)

--- a/src/pages/terms.md
+++ b/src/pages/terms.md
@@ -1,0 +1,116 @@
+---
+title: Terms of Use / EULA
+description: 'The End-User License Agreement for the ZenUML product family — Confluence, web, JetBrains, VS Code, and desktop apps, from P&D Vision Pty Ltd.'
+keywords:
+  [
+    zenuml terms of use,
+    zenuml eula,
+    end user license agreement,
+    zenuml license terms,
+    p&d vision pty ltd,
+  ]
+unlisted: false
+---
+
+# Terms of Use / EULA
+
+End User License Agreement (EULA) for ZenUML apps
+
+## 1. Introduction
+
+This End-User License Agreement ("EULA") is a legal agreement between you and P&D Vision Pty Ltd.
+
+This EULA agreement governs your acquisition and use of our ZenUML Apps software ("Software")
+across the ZenUML product family — via Atlassian's platform (the marketplace and any Confluence or
+Jira installation), the JetBrains Marketplace, the Visual Studio Code Marketplace, or as a directly
+downloaded web, desktop, or browser-extension application.
+
+If you register for a free trial of the ZenUML Apps software, this EULA agreement will also govern that
+trial. By clicking "accept" or installing and/or using the ZenUML Apps software, you are confirming your
+acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.
+
+## 2. Agreement to Terms and Conditions
+
+This Agreement takes effect on the date on which you install or first use the ZenUML software.
+
+## 3. License Duration
+
+This license is perpetual, no additional payment is required to maintain it, with the exception
+of you breaking any part of this license, in which case you lose all rights under the license.
+
+## 4. Disclaimer
+
+It is not warranted that any software supplied by P&D Vision Pty Ltd will meet your requirements
+or that its operation will be uninterrupted or error free. P&D Vision Pty Ltd exclude and
+expressly disclaim all express and implied warranties or conditions not stated in this Agreement
+(including without limitation, loss of profits, loss or corruption of data, business interruption
+or loss of contracts), so far as such exclusion or disclaimer is permitted under the applicable law.
+This Agreement does not affect your statutory rights.
+
+## 5. Warranties and Limitation of Liability
+
+P&D Vision Pty Ltd warrants that its software and services will be provided using reasonable care
+and skill on a non-exclusive basis. Where P&D Vision Pty Ltd supplies any goods supplied by a third
+party, P&D Vision Pty Ltd does not give any warranty, guarantee or other term as to their quality,
+fitness for purpose or otherwise, but shall, where possible, assign the benefit of any warranty,
+guarantee or indemnity given by the person supplying the goods to P&D Vision Pty Ltd. P&D Vision Pty Ltd
+shall not be liable to you by reason of any representation (unless fraudulent), or any implied
+warranty, condition or other term, or any duty at common law, for any loss of profit or any indirect,
+special or consequential loss, damage, costs, expenses or other claims (whether caused by
+P&D Vision Pty Ltd's negligence or the negligence of its servants or agents or otherwise)
+which arise out of or in connection with the provision of any goods or services by P&D Vision Pty Ltd.
+
+Notwithstanding contrary clauses in this Agreement, in the event that P&D Vision Pty Ltd are deemed
+liable to you for breach of this Agreement, you agree that P&D Vision Pty Ltd's liability is limited
+to the amount actually paid by you for your services or software, which amount calculated in reliance
+upon this clause. You hereby release P&D Vision Pty Ltd from any and all obligations, liabilities and
+claims in excess of this limitation.
+
+## 6. Use of Names and Logos
+
+By using our services, you grant P&D Vision Pty Ltd the right to use your name and logo in our marketing
+and promotional materials, including but not limited to our website, social media, and print materials.
+This right is granted unless you explicitly request in writing that we cease such use. If you wish to
+withdraw this permission, please contact us at support@zenuml.com and we will promptly comply with
+your request.
+
+## 7. Notices and Consents
+
+Any notice, request or other communication to either party by the other under this Agreement shall be
+given by email, fax or conventional mail.
+
+## 8. Assignment of Rights
+
+You shall not assign this Agreement or any benefits or interests arising under this Agreement without
+P&D Vision Pty Ltd's prior written permission, such not to be unreasonably withheld.
+
+## 9. Ownership
+
+P&D Vision Pty Ltd reserves the right to use in any way it wishes any programming tools, skills, content,
+methodologies, strategies and techniques acquired or used in performing its duties under this Agreement.
+The ownership of any data content created using the software shall remain with the author of that content.
+P&D Vision Pty Ltd provides permission for text, vector and raster representations within the software that it
+owns to be combined with the representation that the author has created and for the combined result to be
+persisted in either vector and/or raster format. You may use such graphically persisted representation that
+you create for any purpose that does not interfere with the business operations of P&D Vision Pty Ltd.
+
+## 10. General Terms and Law
+
+This EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be
+governed by and construed in accordance with the laws of Australia.
+
+## 11. Severability
+
+If any of the provisions of this Agreement is judged to be illegal or unenforceable, the remainder shall
+continuation in full force and the effect of the remainder of them will be not be deemed to be prejudiced
+(unless the substantive purpose of this Agreement is then frustrated, in which case either party may terminate
+this Agreement forthwith on written notice).
+
+## 12. Entire Agreement
+
+This Agreement constitutes the entire agreement between P&D Vision Pty Ltd and you with respect to your use of
+services, software and/or goods provided by P&D Vision Pty Ltd, and it supersedes all prior or contemporaneous
+communications and proposals, whether oral or written, between P&D Vision Pty Ltd and you with respect thereto.
+Each party confirms that it has not relied on any representation not recorded in this document inducing it to
+enter into this Agreement. The address for communication to P&D Vision Pty Ltd by email unless you are otherwise
+notified shall be: [support@zenuml.com](mailto:support@zenuml.com).


### PR DESCRIPTION
## Finding

A crawl probe today found `zenuml.com/privacy` and `zenuml.com/terms` both returning 404, and no `/about` or visible contact page exists. This is an E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness) gap: search engines and AI answer engines weight the presence of a real privacy policy, terms of use, and an identifiable operator/contact when assessing site trust, and we had none of the three reachable on the primary domain.

The footer previously linked "Privacy Policy" and "EULA" out to `app.zenuml.com/privacy-policy/...` and `app.zenuml.com/End-User-License-Agreement/...` — off-domain, and not the pages search engines associate with zenuml.com.

## What changed

- `src/pages/privacy.md` → `/privacy/` — ported from `conf-app/public/Privacy-Policy.md`, with the opening paragraph broadened from "the ZenUML Apps on Atlassian Confluence" to name the full product family (Confluence, web app, JetBrains/VS Code, desktop) and explicitly attribute ZenUML to its operator, P&D Vision Pty Ltd. No clauses added or removed; contact email (`support@zenuml.com`) unchanged.
- `src/pages/terms.md` → `/terms/` — ported from `conf-app/public/EULA.md`, titled "Terms of Use / EULA". Same minimal-adaptation rule: the distribution-channel description in §1 was broadened to include the JetBrains/VS Code marketplaces and direct web/desktop downloads (previously only described Atlassian's marketplace). All 12 numbered clauses, the operator identity (P&D Vision Pty Ltd), and the contact email are unchanged from source.
- `src/pages/about.md` → `/about/` — new page, built only from already-published facts (site's `static/llms.txt`, `src/pages/index.tsx` About/Privacy sections, `docusaurus.config.ts` Organization JSON-LD): product family description, where it runs, the finance-industry origin, the in-browser-rendering privacy claim, and links to Privacy/Terms. No invented team size, address, founding year, or customer claims. Includes a visible `mailto:support@zenuml.com` contact block to satisfy the Contact requirement of E-E-A-T.
- `docusaurus.config.ts` — replaced the off-domain "EULA" / "Privacy Policy" footer links (in the "More" column) with a new "Legal" footer column pointing at the new on-domain pages: About, Privacy Policy, Terms of Use / EULA.

## Verification done

- `./node_modules/.bin/docusaurus build` — succeeds (pre-existing duplicate-blog-route warning is unrelated, present on main).
- Confirmed `build/privacy/index.html`, `build/terms/index.html`, `build/about/index.html` all exist.
- Confirmed all three URLs appear in `build/sitemap.xml`.
- Confirmed rendered `<title>`, meta description, canonical URL, and OG tags for each page (titles ≤60 chars including the Docusaurus-appended " | ZenUML" suffix; descriptions 120–160 chars).
- Confirmed the built homepage footer (`build/index.html`) contains `href="/about/"`, `href="/privacy/"`, `href="/terms/"` under the new Legal column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LooeVhpxC5qb8HzW6mvQ3