### PR TITLE
fix(seo): close FN02/FN03 — blog meta on T3-renamed posts

### DIFF
--- a/blog/2024/2024-09-12.md
+++ b/blog/2024/2024-09-12.md
@@ -1,5 +1,5 @@
 ---
-title: 'Understanding Sequence Diagrams: Your Guide to the Next Big Thing in Business Analysis'
+title: 'Sequence Diagrams in Business Analysis: A Guide'
 description: 'Discover how sequence diagrams revolutionize business analysis. Explore their structure, benefits, and practical applications.'
 authors: [xiaowenz]
 slug: understanding-sequence-diagrams-in-business-analysis

--- a/blog/2024/2024-09-14.md
+++ b/blog/2024/2024-09-14.md
@@ -1,6 +1,6 @@
 ---
 title: 'Mastering Sequence Diagrams with JavaScript'
-description: 'Learn how to create and optimize sequence diagrams using JavaScript for better software visualization.'
+description: 'Learn how to create sequence diagrams using JavaScript and ZenUML.js, with best practices for role definition, communication flow, and modular design.'
 authors: [xiaowenz]
 slug: mastering-sequence-diagrams-with-javascript
 tags:


### PR DESCRIPTION
## Summary

Mechanical follow-ups from tonight's re-audit (`DELTA.md`, findings FN02/FN03). Both pages are the
two posts T3 renamed to resolve a slug collision (F09) — neither existed as a distinct, checkable
URL until that rename, so they were never in T3's F12–F22 meta-content fix pass and inherited their
original overlong/short meta values verbatim.

| ID | Page | Before | After |
|----|------|--------|-------|
| FN02 | `/blog/understanding-sequence-diagrams-in-business-analysis/` | title 95 chars (frontmatter 86 + `\| ZenUML`), H1 86 chars | title **56** chars, H1 **47** chars |
| FN03 | `/blog/mastering-sequence-diagrams-with-javascript/` | description 102 chars | description **150** chars |

FN02's H1 fix is a side effect, not a separate edit — Docusaurus's blog theme renders the frontmatter
`title` directly as the `<h1>` (no separate body heading on this post), so trimming the title
cascades into the H1, same mechanism T6 documented for F22.

FN03's new description is drawn from the post's own content (best practices for role definition,
communication flow, and modular diagram design with ZenUML.js — matches its own H2/H3 structure).

## Verification

`./node_modules/.bin/docusaurus build` — clean. Rendered HTML checked directly:

```
<title data-rh="true">Sequence Diagrams in Business Analysis: A Guide | ZenUML</title>
<h1 class="title_LClo" itemprop="headline">Sequence Diagrams in Business Analysis: A Guide</h1>
<meta data-rh="true" name="description" content="Learn how to create sequence diagrams using JavaScript and ZenUML.js, with best practices for role definition, communication flow, and modular design.">
```

Title 56 chars (50-60 range), H1 47 chars, description 150 chars (120-160 range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LooeVhpxC5qb8HzW6mvQ3