### PR TITLE
Fix: restore code examples dropped by the /confluence HTML-to-markdown port

### DIFF
--- a/src/pages/confluence/diagram-types/mermaid.md
+++ b/src/pages/confluence/diagram-types/mermaid.md
@@ -41,6 +41,14 @@ ZenUML for Confluence brings the same Mermaid.js library into your Atlassian wor
 
 The code below is a complete Mermaid flowchart. Paste it into a ZenUML macro set to the Mermaid type and it renders immediately — no configuration required.
 
+```mermaid
+graph TD
+  A[User] --> B{Login?}
+  B -- Yes --> C[Dashboard]
+  B -- No -->  D[Login Page]
+  D --> B
+```
+
 This syntax is identical to what you would write in a GitHub README fenced code block — no changes required when moving between tools.
 
 ## Supported Mermaid diagram types

--- a/src/pages/confluence/diagram-types/plantuml.md
+++ b/src/pages/confluence/diagram-types/plantuml.md
@@ -59,6 +59,51 @@ All major PlantUML diagram categories are supported. Write standard `@startuml �
 
 The snippet below is a complete PlantUML class diagram. Paste it directly into the ZenUML macro editor — no modifications needed.
 
+```plantuml
+@startuml
+
+skinparam classAttributeIconSize 0
+
+package "Order Service" {
+
+  class Order {
+    +id: UUID
+    +status: OrderStatus
+    +createdAt: DateTime
+    +totalAmount: Money
+    +place()
+    +cancel()
+  }
+
+  class OrderItem {
+    +productId: UUID
+    +quantity: Int
+    +unitPrice: Money
+  }
+
+  enum OrderStatus {
+    PENDING
+    CONFIRMED
+    SHIPPED
+    DELIVERED
+    CANCELLED
+  }
+
+  class Customer {
+    +id: UUID
+    +email: String
+    +name: String
+  }
+
+}
+
+Customer "1" --> "0..*" Order : places
+Order "1" *-- "1..*" OrderItem : contains
+Order -> OrderStatus : has
+
+@enduml
+```
+
 ### Package grouping
 
 The `package` keyword groups related classes into a named boundary — useful for bounded-context documentation and microservice domain maps.

--- a/src/pages/confluence/diagram-types/sequence-diagrams.md
+++ b/src/pages/confluence/diagram-types/sequence-diagrams.md
@@ -41,11 +41,18 @@ Inside Confluence, ZenUML sequence diagrams live in a macro on the page. The sou
 
 ZenUML DSL models sequence diagrams as **call expressions** — the same mental model developers use when reading or writing code. Participants are inferred automatically from the messages you write, eliminating the boilerplate declarations that PlantUML requires. The result is diagrams that are typically **2-3× shorter** than equivalent PlantUML source while remaining fully UML-compliant.
 
-## ZenUML DSL — a four-message order flow
+## ZenUML DSL — a four-message order flow {#code-example}
 
 Participants are inferred from message sources and targets. No declarations, no boilerplate. The `-->` arrow denotes an asynchronous or return message. Dashes render as a dashed line on the diagram.
 
-order-flow.zenuml
+```zenuml title="order-flow.zenuml"
+title Order Flow
+
+Client -> OrderService: placeOrder(items)
+OrderService -> InventoryService: checkStock(items)
+InventoryService --> OrderService: stockAvailable
+OrderService --> Client: orderConfirmed
+```
 
 ✓ 5 lines of source — no boilerplate ✓ Participants auto-inferred ✓ UML 2.5.1 compliant output
 
@@ -53,17 +60,37 @@ order-flow.zenuml
 
 Both syntaxes produce the same sequence diagram. ZenUML DSL removes the delimiter scaffolding, eliminates participant declarations (they are inferred), and uses a call-expression style that reads more like code. The result is typically 2-3× fewer lines for the same diagram.
 
-ZenUML DSL 5 lines
+**ZenUML DSL — 5 lines**
 
-`title Order Flow Client -> OrderService: placeOrder(items) OrderService -> InventoryService: checkStock(items) InventoryService --> OrderService: stockAvailable OrderService --> Client: orderConfirmed`
+```zenuml
+title Order Flow
+
+Client -> OrderService: placeOrder(items)
+OrderService -> InventoryService: checkStock(items)
+InventoryService --> OrderService: stockAvailable
+OrderService --> Client: orderConfirmed
+```
 
 - ✓ No `@startuml` / `@enduml` delimiters
 - ✓ Participants inferred — no declarations needed
 - ✓ Call-expression style mirrors code semantics
 
-PlantUML (equivalent) 12 lines
+**PlantUML (equivalent) — 12 lines**
 
-`@startuml title Order Flow participant Client participant OrderService participant InventoryService Client -> OrderService : placeOrder(items) OrderService -> InventoryService : checkStock(items) InventoryService --> OrderService : stockAvailable OrderService --> Client : orderConfirmed @enduml`
+```plantuml
+@startuml
+title Order Flow
+
+participant Client
+participant OrderService
+participant InventoryService
+
+Client -> OrderService : placeOrder(items)
+OrderService -> InventoryService : checkStock(items)
+InventoryService --> OrderService : stockAvailable
+OrderService --> Client : orderConfirmed
+@enduml
+```
 
 - ✗ Requires delimiter boilerplate
 - ✗ Must declare every participant explicitly
@@ -141,7 +168,14 @@ Common questions about ZenUML sequence diagrams in Confluence — syntax, compar
 
 ### What is ZenUML sequence diagram syntax?
 
-ZenUML DSL is a text-based syntax for writing **OMG UML 2.5.1-compliant sequence diagrams**. It uses a call-expression style that mirrors how developers think about code execution: `Client -> OrderService: placeOrder(items) OrderService --> Client: orderConfirmed` Participants are inferred automatically from messages — no explicit declarations needed. Notes, combined fragments (alt, loop, opt, par), self-calls, and return arrows are all supported. The source is stored as plain text in Confluence custom content and rendered in the browser via the ZenUML engine.
+ZenUML DSL is a text-based syntax for writing **OMG UML 2.5.1-compliant sequence diagrams**. It uses a call-expression style that mirrors how developers think about code execution:
+
+```zenuml
+Client -> OrderService: placeOrder(items)
+OrderService --> Client: orderConfirmed
+```
+
+Participants are inferred automatically from messages — no explicit declarations needed. Notes, combined fragments (alt, loop, opt, par), self-calls, and return arrows are all supported. The source is stored as plain text in Confluence custom content and rendered in the browser via the ZenUML engine.
 
 ### How does ZenUML DSL compare to PlantUML sequence syntax?
 
@@ -153,7 +187,17 @@ Yes. ZenUML for Confluence includes a full **Mermaid.js renderer** alongside the
 
 ### How do I document API flows in Confluence?
 
-Insert a ZenUML macro on any Confluence page and choose the **Sequence** type. Write your API interaction in ZenUML DSL — for example: `title Order Flow Client -> OrderService: placeOrder(items) OrderService -> InventoryService: checkStock(items) InventoryService --> OrderService: stockAvailable OrderService --> Client: orderConfirmed` Publish the page and the diagram renders inline for all readers. For REST or GraphQL API contracts, pair the sequence diagram with the [OpenAPI macro](/confluence/diagram-types/openapi/) in the same app — interactive swagger-ui renders alongside the sequence diagram on the same Confluence page.
+Insert a ZenUML macro on any Confluence page and choose the **Sequence** type. Write your API interaction in ZenUML DSL — for example:
+
+```zenuml
+title Order Flow
+Client -> OrderService: placeOrder(items)
+OrderService -> InventoryService: checkStock(items)
+InventoryService --> OrderService: stockAvailable
+OrderService --> Client: orderConfirmed
+```
+
+Publish the page and the diagram renders inline for all readers. For REST or GraphQL API contracts, pair the sequence diagram with the [OpenAPI macro](/confluence/diagram-types/openapi/) in the same app — interactive swagger-ui renders alongside the sequence diagram on the same Confluence page.
 
 ### Can I export sequence diagrams to PNG?
 

--- a/src/pages/confluence/faq.md
+++ b/src/pages/confluence/faq.md
@@ -69,6 +69,13 @@ Partially, depending on the source format:
 
 A ZenUML sequence diagram describes interactions between participants (people, services, systems) over time using a text-based DSL (domain-specific language). The ZenUML DSL is designed to be more readable and maintainable than traditional UML text formats. For example:
 
+```zenuml
+Client -> OrderService.placeOrder(item) {
+  OrderService -> Inventory.checkStock(item)
+  return orderId
+}
+```
+
 This renders a clean, standards-compliant UML sequence diagram. Because diagrams live as code, they are diffable in version control, reviewable in pull requests, and reproducible from a plain-text source.
 
 ### What Mermaid diagram types are supported?


### PR DESCRIPTION
User report: /confluence/diagram-types/sequence-diagrams/ shows no diagram examples.

Root cause: the one-time HTML→markdown converter used in #150 handled h1-h6/p/ul/ol/table/div but
never `<pre>` — every multi-line code example was either silently dropped or collapsed into a
single-line inline-code span. 8 blocks lost across 4 pages (verified against the original HTML in
conf-app/website/):

- sequence-diagrams: 5 (hero DSL example, ZenUML-vs-PlantUML comparison pair, 2 FAQ answers)
- mermaid: 1 (flowchart example — the page literally said "The code below…" with nothing below)
- plantuml: 1 (583-char class-diagram example, restored verbatim from the original)
- faq: 1 (ZenUML DSL sample)

All restored as fenced code blocks with language info strings; the sequence page's dangling
`#code-example` anchor now resolves (heading id added). Build green; all 4 built pages carry the
expected `<pre>` counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LooeVhpxC5qb8HzW6mvQ3